### PR TITLE
DOC: add intro and web api feature documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,21 @@
-# Arcus Template
-Template repository for new components in Arcus ecosystem inspired by [.NET Boxed](https://github.com/Dotnet-Boxed/Templates).
+# Arcus Templates
+[![Build Status](https://dev.azure.com/codit/Arcus/_apis/build/status/Commit%20builds/CI%20-%20Arcus.Templates?branchName=master)](https://dev.azure.com/codit/Arcus/_build/latest?definitionId=765&branchName=master)
+
+Template repository for new components in Arcus ecosystem.
 
 ![Arcus](https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png)
+
+# Installation
+
+## Web API
+
+```shell
+> dotnet new -i Arcus.Templates.WebApi
+```
+
+# Documentation
+
+All documentation can be found on [here](https://templates.arcus-azure.net/).
+
+# License Information
+This is licensed under The MIT License (MIT). Which means that you can use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the web application. But you always need to state that Codit is the original author of this web application.

--- a/docs/features/web-api-template.md
+++ b/docs/features/web-api-template.md
@@ -1,0 +1,38 @@
+---
+title: "Web API template"
+layout: default
+---
+
+# Web API Project Template
+
+## Create Your First Arcus Web API Project
+
+First, install the template from NuGet:
+
+```shell
+> dotnet new -i Arcus.Templates.WebApi
+```
+
+When installed, the template can be created with shortname: `arcus-webapi`:
+
+```shell
+> dotnet new arcus-webapi -n MyProject -o C:\temp\myproject
+```
+
+
+## Features
+
+Creates a starter web API project with by default configured:
+* [Exception middleware](https://webapi.arcus-azure.net/features/logging) to log unhandled exceptions thrown during request processing.
+* Content negotiation that only supports `application/json`.
+* Swagger docs generation and UI only available in PROD environment.
+* [Health checks](https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/health-checks?view=aspnetcore-2.2) (_middleware only_) and health endpoint (_based on _[info gained via health checks](https://www.codit.eu/blog/documenting-asp-net-core-health-checks-with-openapi/)_).
+* Docker building file.
+* Default console logger.
+
+## Configuration
+
+And additional features available with options:
+* `-A|--Authentication` (default `None`)
+  * `SharedAccessKey`: adds [shared access key authentication](https://webapi.arcus-azure.net/features/security/auth/shared-access-key) mechanism to the API project
+  * `None`: no authentication configured on the API project.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,11 +8,13 @@ redirect_from:
 
 # Installation
 
-Coming soon!
+## Web API
 
-# Features
+```shell
+PM > dotnet new -i Arcus.Templates.WebApi
+```
 
-Coming soon!
+Read [here](features/web-api-template) for standard and configurable features.
 
 # License
 This is licensed under The MIT License (MIT). Which means that you can use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the web application. But you always need to state that Codit is the original author of this web application.


### PR DESCRIPTION
* Adds introduction page for the global 'arcus templates' project.
* Provide a simple structure of the current state of the web API project and the already available auth option.

Relates to #6 
Relates to #12 