### PR TITLE
Build requires 'Package.Version', not 'Package.Version.ManualTrigger'

### DIFF
--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -21,7 +21,7 @@ variables:
     value: '5000'
   - name: 'Arcus_Api_BaseUrl'
     value: 'http://localhost:$(Http.Port)/api/v1'
-  # 'Package.Version.ManualTrigger' is added as queue-time variable on build in Azure DevOps
+  # 'Package.Version' is added as queue-time variable on build in Azure DevOps
 
 stages:
   - stage: Build


### PR DESCRIPTION
Signed-off-by: Tom Kerkhove <kerkhove.tom@gmail.com>