### PR TITLE
Docs - Use "dotnet new" example in GitHub release

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ We provide a template to build Web APIs. ([docs](https://templates.arcus-azure.n
 
 First, install the template:
 ```shell
-> dotnet new -i Arcus.Templates.WebApi
+> dotnet new --install Arcus.Templates.WebApi
 ```
 
 When installed, the template can be created with shortname: arcus-webapi:

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -123,7 +123,7 @@ stages:
               releaseNotes: |
                 Install new version via [NuGet](https://www.nuget.org/packages/Arcus.Template.WebApi/$(Build.BuildNumber))
                 ```shell
-                > Install-Package Arcus.Template.WebApi -Version $(Build.BuildNumber)
+                > dotnet new --install Arcus.Templates.WebApi:$(Build.BuildNumber)
                 ```
             condition: not(contains(variables['Build.BuildNumber'], '-'))
           - task: GitHubRelease@0
@@ -138,7 +138,7 @@ stages:
               releaseNotes: |
                 Install new version via [NuGet](https://www.nuget.org/packages/Arcus.Template.WebApi/$(Build.BuildNumber))
                 ```shell
-                > Install-Package Arcus.Template.WebApi -Version $(Build.BuildNumber)
+                > dotnet new --install Arcus.Templates.WebApi:$(Build.BuildNumber)
                 ```
               isPreRelease: true
               compareWith: 'lastRelease'

--- a/docs/features/web-api-template.md
+++ b/docs/features/web-api-template.md
@@ -10,7 +10,7 @@ layout: default
 First, install the template from NuGet:
 
 ```shell
-> dotnet new -i Arcus.Templates.WebApi
+> dotnet new --install Arcus.Templates.WebApi
 ```
 
 When installed, the template can be created with shortname: `arcus-webapi`:

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ redirect_from:
 ## Web API
 
 ```shell
-PM > dotnet new -i Arcus.Templates.WebApi
+PM > dotnet new --install Arcus.Templates.WebApi
 ```
 
 Read [here](features/web-api-template) for standard and configurable features.


### PR DESCRIPTION
- Use `dotnet new` example instead of `Install-Package` in GitHub release
- Use `--install` rather than `-i` to be more explicit