### PR TITLE
Docs - Use "dotnet new --name" instead of "dotnet new -n"

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ First, install the template:
 
 When installed, the template can be created with shortname: arcus-webapi:
 ```shell
-> dotnet new arcus-webapi -n Arcus.Demo.WebAPI
+> dotnet new arcus-webapi --name Arcus.Demo.WebAPI
 ```
 
 # Documentation

--- a/docs/features/web-api-template.md
+++ b/docs/features/web-api-template.md
@@ -16,7 +16,7 @@ First, install the template from NuGet:
 When installed, the template can be created with shortname: `arcus-webapi`:
 
 ```shell
-> dotnet new arcus-webapi -n Arcus.Demo.WebAPI
+> dotnet new arcus-webapi --name Arcus.Demo.WebAPI
 ```
 
 


### PR DESCRIPTION
Use "dotnet new --name" instead of "dotnet new -n" to make it clear what it is for, not everybody knows this.