### PR TITLE
FIX: use build errors instead of warnings to incidate missing values

### DIFF
--- a/src/Arcus.Templates.Tests.Integration/Fixture/WebApiProjectOptions.cs
+++ b/src/Arcus.Templates.Tests.Integration/Fixture/WebApiProjectOptions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Arcus.Security.Secrets.Core.Caching;
 using Arcus.Security.Secrets.Core.Interfaces;
 using GuardNet;
 
@@ -77,7 +78,7 @@ namespace Arcus.Templates.Tests.Integration.Fixture
                 + $"new {typeof(Dictionary<string, string>).Namespace}.{nameof(Dictionary<string, string>)}<string, string> {{ [\"{secretName}\"] = \"{secretValue}\" }})";
 
             startupContent = 
-                startupContent.Replace("secretProvider: null", newSecretProviderWithSecret)
+                startupContent.Replace($"new {nameof(CachedSecretProvider)}()", $"new {nameof(CachedSecretProvider)}({newSecretProviderWithSecret})")
                               .Replace("YOUR REQUEST HEADER NAME", requestHeader)
                               .Replace("YOUR SECRET NAME", secretName);
 

--- a/src/Arcus.Templates.WebApi/Arcus.Templates.WebApi.csproj
+++ b/src/Arcus.Templates.WebApi/Arcus.Templates.WebApi.csproj
@@ -36,10 +36,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <DefineConstants>$(DefineConstants);NoneAuth;Auth;SharedAccessKeyAuth</DefineConstants>
-    <NoneAuth>false</NoneAuth>
-    <Auth>true</Auth>
-    <SharedAccessKeyAuth>true</SharedAccessKeyAuth>
+    <DefineConstants>$(DefineConstants);</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Arcus.Templates.WebApi/Startup.cs
+++ b/src/Arcus.Templates.WebApi/Startup.cs
@@ -26,7 +26,7 @@ namespace Arcus.Templates.WebApi
         {
 #if Auth
             #warning Please provide a valid secret provider, for example Azure Key Vault: https://security.arcus-azure.net/features/secrets/consume-from-key-vault
-            services.AddScoped<ICachedSecretProvider>(serviceProvider => new CachedSecretProvider(secretProvider: null));
+            services.AddScoped<ICachedSecretProvider>(serviceProvider => new CachedSecretProvider());
 #endif
 
             services.AddMvc(options => 


### PR DESCRIPTION
Use build errors to indicate user-provided values. In this case, the `secretProvider: null` is removed so we get a compilation error about not finding the right `CachedSecretProvider` constructor.

Closes #48 