### PR TITLE
Fix CI triggers for PRs & branch-based builds

### DIFF
--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -3,16 +3,16 @@ name: $(date:yyyyMMdd)$(rev:.r)
 trigger:
   branches:
     include:
-      - master
+    - master
   paths:
     include:
-      - src/*
+    - src/*
 
 pr:
   paths:
     include:
-      - src/*
-      - build/ci-build.yml
+    - src/*
+    - build/ci-build.yml
 
 resources:
   repositories:


### PR DESCRIPTION
Fix CI triggers for PRs & branch-based builds given they are not kicking in for PRs.