### PR TITLE
Use nuget/publish-preview-package.yml instead of old version

### DIFF
--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -166,6 +166,6 @@ stages:
             inputs:
               artifact: 'Templates'
               path: '$(Build.SourcesDirectory)/templates'
-          - template: build/nuget/publish-preview-package.yml@templates
+          - template: nuget/publish-preview-package.yml@templates
             parameters:
               packagesToPush: 'templates/*.nupkg'


### PR DESCRIPTION
Use nuget/publish-preview-package.yml instead of build/nuget/publish-preview-package.yml

Relates to https://github.com/arcus-azure/azure-devops-templates/pull/12