### PR TITLE
FEAT: add Open API security definitions as project option

### DIFF
--- a/docs/features/web-api-template.md
+++ b/docs/features/web-api-template.md
@@ -37,6 +37,8 @@ And additional features available with options:
   * `SharedAccessKey`: adds [shared access key authentication](https://webapi.arcus-azure.net/features/security/auth/shared-access-key) mechanism to the API project
   * `Certificate`: adds [client certificate authentication](https://webapi.arcus-azure.net/features/security/auth/certificate) mechanism to the API project
   * `None`: no authentication configured on the API project.
+* `-osd|--openapi-security-definitions` (default `false`): adds [OAuth security definitions](https://webapi.arcus-azure.net/features/openapi/security-definitions) to authorized API operations in the Open API specification file.
+
 
 ## Security
 As part of this template the following HTTP header(s) are removed for security sake:

--- a/src/Arcus.Templates.Tests.Integration/Arcus.Templates.Tests.Integration.csproj
+++ b/src/Arcus.Templates.Tests.Integration/Arcus.Templates.Tests.Integration.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Polly" Version="7.1.1" />
     <PackageReference Include="System.Web.Http" Version="4.0.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="1.1.1" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>

--- a/src/Arcus.Templates.Tests.Integration/Arcus.Templates.Tests.Integration.csproj
+++ b/src/Arcus.Templates.Tests.Integration/Arcus.Templates.Tests.Integration.csproj
@@ -30,9 +30,9 @@
     <PackageReference Include="Flurl.Http" Version="2.4.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.1.4" />
     <PackageReference Include="Polly" Version="7.1.1" />
     <PackageReference Include="System.Web.Http" Version="4.0.0" />
-    <PackageReference Include="Microsoft.OpenApi" Version="1.1.1" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>

--- a/src/Arcus.Templates.Tests.Integration/Fixture/AuthorizedAndNoneAuthorizedController.cs
+++ b/src/Arcus.Templates.Tests.Integration/Fixture/AuthorizedAndNoneAuthorizedController.cs
@@ -1,5 +1,4 @@
 ﻿using System.Net.Http;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -14,16 +13,16 @@ namespace Arcus.Templates.Tests.Integration.Fixture
         [HttpGet]
         [Route(AuthorizedRoute)]
         [Authorize]
-        public Task<IActionResult> GetAuthorizedRoute(HttpRequestMessage request)
+        public IActionResult GetAuthorizedRoute(HttpRequestMessage request)
         {
-            return Task.FromResult<IActionResult>(Ok());
+            return Ok();
         }
 
         [HttpGet]
         [Route(NoneAuthorizedRoute)]
-        public Task<IActionResult> GetNoneAuthorizedRoute(HttpRequestMessage request)
+        public IActionResult GetNoneAuthorizedRoute(HttpRequestMessage request)
         {
-            return Task.FromResult<IActionResult>(Ok());
+            return Ok();
         }
     }
 }

--- a/src/Arcus.Templates.Tests.Integration/Fixture/AuthorizedAndNoneAuthorizedController.cs
+++ b/src/Arcus.Templates.Tests.Integration/Fixture/AuthorizedAndNoneAuthorizedController.cs
@@ -1,0 +1,30 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Arcus.Templates.Tests.Integration.Fixture
+{
+    [ApiController]
+    public class AuthorizedAndNoneAuthorizedController : ControllerBase
+    {
+        public const string AuthorizedRoute = "auth/authorized",
+                            NoneAuthorizedRoute = "auth/none";
+
+        [HttpGet]
+        [Route(AuthorizedRoute)]
+        [Authorize]
+        public Task<IActionResult> GetAuthorizedRoute(HttpRequestMessage request)
+        {
+            return Task.FromResult<IActionResult>(Ok());
+        }
+
+        [HttpGet]
+        [Route(NoneAuthorizedRoute)]
+        public Task<IActionResult> GetNoneAuthorizedRoute(HttpRequestMessage request)
+        {
+            return Task.FromResult<IActionResult>(Ok());
+        }
+    }
+}
+`

--- a/src/Arcus.Templates.Tests.Integration/Fixture/AuthorizedAndNoneAuthorizedController.cs
+++ b/src/Arcus.Templates.Tests.Integration/Fixture/AuthorizedAndNoneAuthorizedController.cs
@@ -27,4 +27,3 @@ namespace Arcus.Templates.Tests.Integration.Fixture
         }
     }
 }
-`

--- a/src/Arcus.Templates.Tests.Integration/Fixture/TemplateProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/Fixture/TemplateProject.cs
@@ -19,7 +19,7 @@ namespace Arcus.Templates.Tests.Integration.Fixture
         private const string ProjectName = "Arcus.Demo.Project";
 
         private readonly Process _process;
-        private readonly DirectoryInfo _templateDirectory, _fixtureDirectory, _projectDirectory;
+        private readonly DirectoryInfo _templateDirectory;
         private readonly ITestOutputHelper _outputWriter;
 
         private bool _created, _started, _disposed;
@@ -31,14 +31,23 @@ namespace Arcus.Templates.Tests.Integration.Fixture
             Guard.NotNull(outputWriter, nameof(outputWriter));
 
             _process = new Process();
-
             _templateDirectory = templateDirectory;
-            _fixtureDirectory = fixtureDirectory;
             _outputWriter = outputWriter;
 
             string tempDirectoryPath = Path.Combine(Path.GetTempPath(), $"{ProjectName}-{Guid.NewGuid()}");
-            _projectDirectory = new DirectoryInfo(tempDirectoryPath);;
+            ProjectDirectory = new DirectoryInfo(tempDirectoryPath);;
+            FixtureDirectory = fixtureDirectory;
         }
+
+        /// <summary>
+        /// Gets the directory where the fixtures are located that are used when a project requires additional functionality.
+        /// </summary>
+        protected DirectoryInfo FixtureDirectory { get; }
+        
+        /// <summary>
+        /// Gets the directory where a new project is created from the template.
+        /// </summary>
+        protected DirectoryInfo ProjectDirectory { get; }
 
         /// <summary>
         /// Creates a new project from this template at the project directory with a given set of <paramref name="projectOptions"/>.
@@ -54,14 +63,14 @@ namespace Arcus.Templates.Tests.Integration.Fixture
             _created = true;
 
             string shortName = GetTemplateShortNameAtTemplateFolder();
-            _outputWriter.WriteLine($"Creates new project from template {shortName} at {_projectDirectory.FullName}");
+            _outputWriter.WriteLine($"Creates new project from template {shortName} at {ProjectDirectory.FullName}");
             
             RunDotNet($"new -i {_templateDirectory.FullName}");
 
             string commandArguments = projectOptions.ToCommandLineArguments();
-            RunDotNet($"new {shortName} {commandArguments ?? String.Empty} -n {ProjectName} -o {_projectDirectory.FullName}");
+            RunDotNet($"new {shortName} {commandArguments ?? String.Empty} -n {ProjectName} -o {ProjectDirectory.FullName}");
 
-            projectOptions.UpdateProjectToCorrectlyUseOptions(_fixtureDirectory, _projectDirectory);
+            projectOptions.UpdateProjectToCorrectlyUseOptions(FixtureDirectory, ProjectDirectory);
         }
 
         private string GetTemplateShortNameAtTemplateFolder()
@@ -96,9 +105,9 @@ namespace Arcus.Templates.Tests.Integration.Fixture
                 throw new InvalidOperationException("Test demo project from template is already started");
             }
 
-            RunDotNet($"build -c {buildConfiguration} {_projectDirectory.FullName}");
+            RunDotNet($"build -c {buildConfiguration} {ProjectDirectory.FullName}");
 
-            string targetAssembly = Path.Combine(_projectDirectory.FullName, $"bin/{buildConfiguration}/netcoreapp2.2/{ProjectName}.dll");
+            string targetAssembly = Path.Combine(ProjectDirectory.FullName, $"bin/{buildConfiguration}/netcoreapp2.2/{ProjectName}.dll");
             string runCommand = $"exec {targetAssembly} {commandArguments ?? String.Empty}";
             
             _outputWriter.WriteLine("> dotnet {0}", runCommand);
@@ -106,7 +115,7 @@ namespace Arcus.Templates.Tests.Integration.Fixture
             {
                 UseShellExecute = false,
                 CreateNoWindow = true,
-                WorkingDirectory = _projectDirectory.FullName,
+                WorkingDirectory = ProjectDirectory.FullName,
             };
 
             _process.StartInfo = processInfo;
@@ -193,7 +202,7 @@ namespace Arcus.Templates.Tests.Integration.Fixture
 
         private void DeleteProjectDirectory()
         {
-            _projectDirectory.Delete(recursive: true);
+            ProjectDirectory.Delete(recursive: true);
         }
 
         private static PolicyResult RetryAction(Action action)

--- a/src/Arcus.Templates.Tests.Integration/Fixture/WebApiProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/Fixture/WebApiProject.cs
@@ -20,6 +20,7 @@ namespace Arcus.Templates.Tests.Integration.Fixture
     {
         private readonly Uri _baseUrl;
         private readonly TestConfig _configuration;
+        private readonly ITestOutputHelper _outputWriter;
 
         private static readonly HttpClient HttpClient = new HttpClient();
 
@@ -36,6 +37,7 @@ namespace Arcus.Templates.Tests.Integration.Fixture
 
             _baseUrl = baseUrl;
             _configuration = configuration;
+            _outputWriter = outputWriter;
 
             Health = new HealthEndpointService(baseUrl, outputWriter);
             Swagger = new SwaggerEndpointService(baseUrl, outputWriter);
@@ -199,7 +201,7 @@ namespace Arcus.Templates.Tests.Integration.Fixture
             await WaitUntilWebProjectIsAvailable(_baseUrl.Port);
         }
 
-        private static async Task WaitUntilWebProjectIsAvailable(int httpPort)
+        private async Task WaitUntilWebProjectIsAvailable(int httpPort)
         {
             var waitAndRetryForeverAsync =
                 Policy.Handle<Exception>()
@@ -212,11 +214,11 @@ namespace Arcus.Templates.Tests.Integration.Fixture
 
             if (result.Outcome == OutcomeType.Successful)
             {
-                outputWriter.WriteLine("Test template web API project fully started at: localhost:{0}", httpPort);
+                _outputWriter.WriteLine("Test template web API project fully started at: localhost:{0}", httpPort);
             }
             else
             {
-                outputWriter.WriteLine("Test template web API project could not be started");
+                _outputWriter.WriteLine("Test template web API project could not be started");
                 throw new CannotStartTemplateProjectException(
                     "The test project created from the web API project template doesn't seem to be running, "
                     + "please check any build or runtime errors that could occur when the test project was created");
@@ -260,7 +262,7 @@ namespace Arcus.Templates.Tests.Integration.Fixture
             else
             {
                 string content = File.ReadAllText(destControllerPath);
-                content = replacements?.Aggregate(content, (txt, kv) => txt.Replace(kv.Key, kv.Value));
+                content = replacements.Aggregate(content, (txt, kv) => txt.Replace(kv.Key, kv.Value));
             
                 File.WriteAllText(destControllerPath, content);
             }

--- a/src/Arcus.Templates.Tests.Integration/Fixture/WebApiProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/Fixture/WebApiProject.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -16,23 +18,45 @@ namespace Arcus.Templates.Tests.Integration.Fixture
     /// </summary>
     public class WebApiProject : TemplateProject
     {
+        private readonly Uri _baseUrl;
+        private readonly TestConfig _configuration;
+
         private static readonly HttpClient HttpClient = new HttpClient();
 
         private WebApiProject(
             Uri baseUrl, 
+            TestConfig configuration,
             DirectoryInfo templateDirectory,
             DirectoryInfo fixturesDirectory,
             ITestOutputHelper outputWriter)
             : base(templateDirectory, fixturesDirectory, outputWriter)
         {
             Guard.NotNull(baseUrl, nameof(baseUrl), "Cannot create a web API services without a test configuration");
+            Guard.NotNull(configuration, nameof(configuration), "Cannot create a web API project without a configuration that describes startup settings");
+
+            _baseUrl = baseUrl;
+            _configuration = configuration;
 
             Health = new HealthEndpointService(baseUrl, outputWriter);
             Swagger = new SwaggerEndpointService(baseUrl, outputWriter);
         }
 
         /// <summary>
-        /// Starts a newly created project from the web API project template with a given set of <paramref name="projectOptions"/>.
+        /// Starts a newly created project from the web API project template without a given set of project options.
+        /// </summary>
+        /// <param name="outputWriter">The output logger to add telemetry information during the creation and startup process.</param>
+        /// <returns>
+        ///     A web API project with a full set of endpoint services to interact with the API.
+        /// </returns>
+        public static async Task<WebApiProject> StartNewAsync(ITestOutputHelper outputWriter)
+        {
+            Guard.NotNull(outputWriter, nameof(outputWriter), "Cannot create web API services without a test output logger");
+
+            return await StartNewAsync(TestConfig.Create(), outputWriter);
+        }
+
+        /// <summary>
+        /// Starts a newly created project from the web API project template without a given set of project options.
         /// </summary>
         /// <param name="configuration">The configuration to control the hosting of the to-be-created project.</param>
         /// <param name="outputWriter">The output logger to add telemetry information during the creation and startup process.</param>
@@ -50,6 +74,22 @@ namespace Arcus.Templates.Tests.Integration.Fixture
         /// <summary>
         /// Starts a newly created project from the web API project template with a given set of <paramref name="projectOptions"/>.
         /// </summary>
+        /// <param name="projectOptions">The project options to control the functionality of the to-be-created project from this template.</param>
+        /// <param name="outputWriter">The output logger to add telemetry information during the creation and startup process.</param>
+        /// <returns>
+        ///     A web API project with a full set of endpoint services to interact with the API.
+        /// </returns>
+        public static async Task<WebApiProject> StartNewAsync(WebApiProjectOptions projectOptions, ITestOutputHelper outputWriter)
+        {
+            Guard.NotNull(projectOptions, nameof(projectOptions), "Cannot create a web API project without a set of project argument options");
+            Guard.NotNull(outputWriter, nameof(outputWriter), "Cannot create web API services without a test output logger");
+
+            return await StartNewAsync(TestConfig.Create(), projectOptions, outputWriter);
+        }
+
+        /// <summary>
+        /// Starts a newly created project from the web API project template with a given set of <paramref name="projectOptions"/>.
+        /// </summary>
         /// <param name="configuration">The configuration to control the hosting of the to-be-created project.</param>
         /// <param name="projectOptions">The project options to control the functionality of the to-be-created project from this template.</param>
         /// <param name="outputWriter">The output logger to add telemetry information during the creation and startup process.</param>
@@ -62,16 +102,101 @@ namespace Arcus.Templates.Tests.Integration.Fixture
             Guard.NotNull(projectOptions, nameof(projectOptions), "Cannot create a web API project without a set of project argument options");
             Guard.NotNull(outputWriter, nameof(outputWriter), "Cannot create web API services without a test output logger");
 
+            WebApiProject project = CreateNew(configuration, projectOptions, outputWriter);
+            await project.StartAsync();
+
+            return project;
+        }
+
+        /// <summary>
+        /// Creates a project from the web API project template without a set project options.
+        /// </summary>
+        /// <param name="outputWriter">The output logger to add telemetry information during the creation and startup process.</param>
+        /// <returns>
+        ///     A not yet started web API project with a full set of endpoint services to interact with the API.
+        /// </returns>
+        /// <remarks>
+        ///     Before the project can be interacted with, the project must be started by calling the <see cref="StartAsync" /> method.
+        /// </remarks>
+        public static WebApiProject CreateNew(ITestOutputHelper outputWriter)
+        {
+            Guard.NotNull(outputWriter, nameof(outputWriter), "Cannot create web API services without a test output logger");
+
+            return CreateNew(TestConfig.Create(), WebApiProjectOptions.Empty, outputWriter);
+        }
+
+        /// <summary>
+        /// Creates a project from the web API project template without a set of project options.
+        /// </summary>
+        /// <param name="configuration">The configuration to control the hosting of the to-be-created project.</param>
+        /// <param name="outputWriter">The output logger to add telemetry information during the creation and startup process.</param>
+        /// <returns>
+        ///     A not yet started web API project with a full set of endpoint services to interact with the API.
+        /// </returns>
+        /// <remarks>
+        ///     Before the project can be interacted with, the project must be started by calling the <see cref="StartAsync" /> method.
+        /// </remarks>
+        public static WebApiProject CreateNew(TestConfig configuration, ITestOutputHelper outputWriter)
+        {
+            Guard.NotNull(configuration, nameof(configuration), "Cannot create a web API project from the template without a test configuration");
+            Guard.NotNull(outputWriter, nameof(outputWriter), "Cannot create web API services without a test output logger");
+
+            return CreateNew(configuration, WebApiProjectOptions.Empty, outputWriter);
+        }
+
+        /// <summary>
+        /// Creates a project from the web API project template without a set of project options.
+        /// </summary>
+        /// <param name="projectOptions">The project options to control the functionality of the to-be-created project from this template.</param>
+        /// <param name="outputWriter">The output logger to add telemetry information during the creation and startup process.</param>
+        /// <returns>
+        ///     A not yet started web API project with a full set of endpoint services to interact with the API.
+        /// </returns>
+        /// <remarks>
+        ///     Before the project can be interacted with, the project must be started by calling the <see cref="StartAsync" /> method.
+        /// </remarks>
+        public static WebApiProject CreateNew(WebApiProjectOptions projectOptions, ITestOutputHelper outputWriter)
+        {
+            Guard.NotNull(projectOptions, nameof(projectOptions), "Cannot create a web API project without a set of project argument options");
+            Guard.NotNull(outputWriter, nameof(outputWriter), "Cannot create web API services without a test output logger");
+
+            return CreateNew(TestConfig.Create(), projectOptions, outputWriter);
+        }
+
+        /// <summary>
+        /// Creates a project from the web API project template with a given set of <paramref name="projectOptions"/>.
+        /// </summary>
+        /// <param name="configuration">The configuration to control the hosting of the to-be-created project.</param>
+        /// <param name="projectOptions">The project options to control the functionality of the to-be-created project from this template.</param>
+        /// <param name="outputWriter">The output logger to add telemetry information during the creation and startup process.</param>
+        /// <returns>
+        ///     A not yet started web API project with a full set of endpoint services to interact with the API.
+        /// </returns>
+        /// <remarks>
+        ///     Before the project can be interacted with, the project must be started by calling the <see cref="StartAsync" /> method.
+        /// </remarks>
+        public static WebApiProject CreateNew(TestConfig configuration, WebApiProjectOptions projectOptions, ITestOutputHelper outputWriter)
+        {
+            Guard.NotNull(configuration, nameof(configuration), "Cannot create a web API project from the template without a test configuration");
+            Guard.NotNull(projectOptions, nameof(projectOptions), "Cannot create a web API project without a set of project argument options");
+            Guard.NotNull(outputWriter, nameof(outputWriter), "Cannot create web API services without a test output logger");
+
             DirectoryInfo templateDirectory = configuration.GetWebApiProjectDirectory();
             DirectoryInfo fixtureDirectory = configuration.GetFixtureProjectDirectory();
             Uri baseUrl = configuration.CreateWebApiBaseUrl();
-            var project = new WebApiProject(baseUrl, templateDirectory, fixtureDirectory, outputWriter);
+            var project = new WebApiProject(baseUrl, configuration, templateDirectory, fixtureDirectory, outputWriter);
             project.CreateNewProject(projectOptions);
-            
-            project.Run(configuration.BuildConfiguration, $"--ARCUS_HTTP_PORT {baseUrl.Port}");
-            await WaitUntilWebProjectIsAvailable(baseUrl.Port);
 
             return project;
+        }
+
+        /// <summary>
+        /// Starts the web API project on a previously configured endpoint.
+        /// </summary>
+        public async Task StartAsync()
+        {
+            Run(_configuration.BuildConfiguration, $"--ARCUS_HTTP_PORT {_baseUrl.Port}");
+            await WaitUntilWebProjectIsAvailable(_baseUrl.Port);
         }
 
         private static async Task WaitUntilWebProjectIsAvailable(int httpPort)
@@ -103,5 +228,52 @@ namespace Arcus.Templates.Tests.Integration.Fixture
         /// Gets the service controlling the Swagger information of the created web API project.
         /// </summary>
         public SwaggerEndpointService Swagger { get; }
+
+        /// <summary>
+        /// Adds a fixture file to the web API project by its type: <typeparamref name="TFixture"/>,
+        /// and replace tokens with values via the given <paramref name="replacements"/> dictionary.
+        /// </summary>
+        /// <typeparam name="TFixture">The fixture type to include in the web API project.</typeparam>
+        /// <param name="replacements">The tokens and their corresponding values to replace in the fixture file.</param>
+        public void AddFixture<TFixture>(IDictionary<string, string> replacements = null)
+        {
+            string srcControllerPath = FindFixtureTypeInDirectory(FixtureDirectory, typeof(TFixture));
+            string destControllerPath = Path.Combine(ProjectDirectory.FullName, nameof(TFixture) + ".cs");
+            File.Copy(srcControllerPath, destControllerPath);
+
+            if (replacements is null)
+            {
+                return;
+            }
+            else
+            {
+                string content = File.ReadAllText(destControllerPath);
+                content = replacements?.Aggregate(content, (txt, kv) => txt.Replace(kv.Key, kv.Value));
+            
+                File.WriteAllText(destControllerPath, content);
+            }
+        }
+
+        private static string FindFixtureTypeInDirectory(DirectoryInfo fixtureDirectory, Type fixtureType)
+        {
+            string fixtureFileName = fixtureType.Name + ".cs";
+            IEnumerable<FileInfo> files = 
+                fixtureDirectory.EnumerateFiles(fixtureFileName, SearchOption.AllDirectories);
+
+            if (!files.Any())
+            {
+                throw new FileNotFoundException(
+                    $"Cannot find fixture with file name: {fixtureFileName} in directory: {fixtureDirectory.FullName}", 
+                    fixtureFileName);
+            }
+
+            if (files.Count() > 1)
+            {
+                throw new IOException(
+                    $"More than a single fixture matches the file name: {fixtureFileName} in directory: {fixtureDirectory.FullName}");
+            }
+
+            return files.First().FullName;
+        }
     }
 }

--- a/src/Arcus.Templates.Tests.Integration/Fixture/WebApiProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/Fixture/WebApiProject.cs
@@ -34,10 +34,11 @@ namespace Arcus.Templates.Tests.Integration.Fixture
         {
             Guard.NotNull(baseUrl, nameof(baseUrl), "Cannot create a web API services without a test configuration");
             Guard.NotNull(configuration, nameof(configuration), "Cannot create a web API project without a configuration that describes startup settings");
+            Guard.NotNull(outputWriter, nameof(outputWriter), "Cannot create a web API project without a test logger that sends diagnostic messages during the creation of the project");
 
             _baseUrl = baseUrl;
             _configuration = configuration;
-            _outputWriter = outputWriter;
+            _outputWriter = outputWriter; 
 
             Health = new HealthEndpointService(baseUrl, outputWriter);
             Swagger = new SwaggerEndpointService(baseUrl, outputWriter);

--- a/src/Arcus.Templates.Tests.Integration/Fixture/WebApiProjectOptions.cs
+++ b/src/Arcus.Templates.Tests.Integration/Fixture/WebApiProjectOptions.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Arcus.Security.Secrets.Core.Interfaces;
 using Arcus.WebApi.Security.Authentication.Certificates;
 using GuardNet;
+using Microsoft.AspNetCore.Authorization;
 
 namespace Arcus.Templates.Tests.Integration.Fixture
 {
@@ -31,6 +32,18 @@ namespace Arcus.Templates.Tests.Integration.Fixture
         /// Creates a set of empty project options for the web API project; resulting in a default web API project when a project is created from these options.
         /// </summary>
         public static readonly WebApiProjectOptions Empty = new WebApiProjectOptions();
+
+        /// <summary>
+        /// Adds Open API security definitions on authorized API endpoints of the web API project.
+        /// </summary>
+        public WebApiProjectOptions WithOpenApiSecurityDefinitions()
+        {
+            ProjectOptions optionsWithOpenApiSecurityDefinitions = AddOption(
+                "--openapi-security-definitions", 
+                (fixtureDirectory, projectDirectory) => { });
+
+            return new WebApiProjectOptions(optionsWithOpenApiSecurityDefinitions);
+        }
 
         /// <summary>
         /// Adds a shared access key authentication to the web API project.

--- a/src/Arcus.Templates.Tests.Integration/Fixture/WebApiProjectOptions.cs
+++ b/src/Arcus.Templates.Tests.Integration/Fixture/WebApiProjectOptions.cs
@@ -3,9 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Arcus.Security.Secrets.Core.Interfaces;
-using Arcus.WebApi.Security.Authentication.Certificates;
 using GuardNet;
-using Microsoft.AspNetCore.Authorization;
 
 namespace Arcus.Templates.Tests.Integration.Fixture
 {
@@ -31,7 +29,7 @@ namespace Arcus.Templates.Tests.Integration.Fixture
         /// <summary>
         /// Creates a set of empty project options for the web API project; resulting in a default web API project when a project is created from these options.
         /// </summary>
-        public static readonly WebApiProjectOptions Empty = new WebApiProjectOptions();
+        public static WebApiProjectOptions Empty { get; } = new WebApiProjectOptions();
 
         /// <summary>
         /// Adds Open API security definitions on authorized API endpoints of the web API project.

--- a/src/Arcus.Templates.Tests.Integration/Swagger/SwaggerEndpointService.cs
+++ b/src/Arcus.Templates.Tests.Integration/Swagger/SwaggerEndpointService.cs
@@ -34,7 +34,7 @@ namespace Arcus.Templates.Tests.Integration.Swagger
         /// <summary>
         /// Sends a GET request to the Swagger UI help page.
         /// </summary>
-        public async Task<HttpResponseMessage> GetSwaggerUI()
+        public async Task<HttpResponseMessage> GetSwaggerUIAsync()
         {
             return await GetAsync(_swaggerUIEndpoint);
         }
@@ -42,7 +42,7 @@ namespace Arcus.Templates.Tests.Integration.Swagger
         /// <summary>
         /// Sends a GET request to the Swagger JSON docs page.
         /// </summary>
-        public async Task<HttpResponseMessage> GetSwaggerDocs()
+        public async Task<HttpResponseMessage> GetSwaggerDocsAsync()
         {
             return await GetAsync(_swaggerDocsEndpoint);
         }

--- a/src/Arcus.Templates.Tests.Integration/Swagger/v1/OpenApiSecurityDefinitionsTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/Swagger/v1/OpenApiSecurityDefinitionsTests.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Arcus.Templates.Tests.Integration.Fixture;
+using Newtonsoft.Json.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Arcus.Templates.Tests.Integration.Swagger.v1
+{
+    [Collection(TestCollections.Integration)]
+    [Trait("Category", TestTraits.Integration)]
+    public class OpenApiSecurityDefinitionsTests
+    {
+        private readonly ITestOutputHelper _outputWriter;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpenApiSecurityDefinitionsTests"/> class.
+        /// </summary>
+        public OpenApiSecurityDefinitionsTests(ITestOutputHelper outputWriter)
+        {
+            _outputWriter = outputWriter;
+        }
+
+        [Fact]
+        public async Task GetSwaggerDocs_WithOpenApiSecurityDefinitionsOption_IncludeSecurityResponsesOnAuthorizedRoutes()
+        {
+            // Arrange
+            var openApiSecurityDefinitionsOptions =
+                new WebApiProjectOptions()
+                    .WithOpenApiSecurityDefinitions();
+            
+            using (var project = WebApiProject.CreateNew(openApiSecurityDefinitionsOptions, _outputWriter))
+            {
+                project.AddFixture<AuthorizedAndNoneAuthorizedController>();
+                await project.StartAsync();
+
+                // Act
+                using (HttpResponseMessage response = await project.Swagger.GetSwaggerDocsAsync())
+                {
+                    // Assert
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                    string swaggerJson = await response.Content.ReadAsStringAsync();
+                    JObject swagger = JObject.Parse(swaggerJson);
+                    var responses = swagger["paths"][$"/{AuthorizedAndNoneAuthorizedController.AuthorizedRoute}"]["get"]["responses"].Children<JProperty>();
+                
+                    Assert.Contains(responses, r => r.Name == "401");
+                    Assert.Contains(responses, r => r.Name == "403");
+                }
+            }
+        }
+
+        [Fact]
+        public async Task GetSwaggerDocs_WithOpenApiSecurityDefinitionsOption_DoesNotIncludeSecurityResponsesOnNonAuthorizedRoutes()
+        {
+            // Arrange
+            var openApiSecurityDefinitionsOptions =
+                new WebApiProjectOptions()
+                    .WithOpenApiSecurityDefinitions();
+
+            using (var project = WebApiProject.CreateNew(openApiSecurityDefinitionsOptions, _outputWriter))
+            {
+                project.AddFixture<AuthorizedAndNoneAuthorizedController>();
+                await project.StartAsync();
+
+                // Act
+                using (HttpResponseMessage response = await project.Swagger.GetSwaggerDocsAsync())
+                {
+                    // Assert
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                    string swaggerJson = await response.Content.ReadAsStringAsync();
+                    JObject swagger = JObject.Parse(swaggerJson);
+                    var responses = swagger["paths"][$"/{AuthorizedAndNoneAuthorizedController.NoneAuthorizedRoute}"]["get"]["responses"].Children<JProperty>();
+                
+                    Assert.DoesNotContain(responses, r => r.Name == "401");
+                    Assert.DoesNotContain(responses, r => r.Name == "403");
+                }
+            }
+        }
+
+        [Fact]
+        public async Task GetSwaggerDocs_WithoutOpenApiSecurityDefinitionsOption_DoesNotIncludeSecurityResponsesOnAuthorizedRoutes()
+        {
+            // Arrange
+            using (var project = WebApiProject.CreateNew(_outputWriter))
+            {
+                project.AddFixture<AuthorizedAndNoneAuthorizedController>();
+                await project.StartAsync();
+
+                // Act
+                using (HttpResponseMessage response = await project.Swagger.GetSwaggerDocsAsync())
+                {
+                    // Assert
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                    string swaggerJson = await response.Content.ReadAsStringAsync();
+                    JObject swagger = JObject.Parse(swaggerJson);
+                    var responses = swagger["paths"][$"/{AuthorizedAndNoneAuthorizedController.AuthorizedRoute}"]["get"]["responses"].Children<JProperty>();
+
+                    Assert.DoesNotContain(responses, r => r.Name == "401");
+                    Assert.DoesNotContain(responses, r => r.Name == "403");
+                }
+            }
+        }
+    }
+}

--- a/src/Arcus.Templates.Tests.Integration/Swagger/v1/OpenApiSecurityDefinitionsTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/Swagger/v1/OpenApiSecurityDefinitionsTests.cs
@@ -1,12 +1,16 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Arcus.Templates.Tests.Integration.Fixture;
-using Newtonsoft.Json.Linq;
+using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Readers;
 using Xunit;
 using Xunit.Abstractions;
+using static Arcus.Templates.Tests.Integration.Fixture.AuthorizedAndNoneAuthorizedController;
 
 namespace Arcus.Templates.Tests.Integration.Swagger.v1
 {
@@ -43,12 +47,24 @@ namespace Arcus.Templates.Tests.Integration.Swagger.v1
                     // Assert
                     Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-                    string swaggerJson = await response.Content.ReadAsStringAsync();
-                    JObject swagger = JObject.Parse(swaggerJson);
-                    var responses = swagger["paths"][$"/{AuthorizedAndNoneAuthorizedController.AuthorizedRoute}"]["get"]["responses"].Children<JProperty>();
-                
-                    Assert.Contains(responses, r => r.Name == "401");
-                    Assert.Contains(responses, r => r.Name == "403");
+                    using (Stream swaggerJson = await response.Content.ReadAsStreamAsync())
+                    {
+                        var streamReader = new OpenApiStreamReader();
+                        OpenApiDocument openApiDoc = streamReader.Read(swaggerJson, out OpenApiDiagnostic diagnostic);
+                        IEnumerable<string> errors = diagnostic.Errors.Select(err => err.Message);
+                        _outputWriter.WriteLine(String.Join(", ", errors));
+
+                        Assert.NotNull(openApiDoc);
+                        Assert.NotNull(openApiDoc.Paths);
+                        Assert.True(openApiDoc.Paths.TryGetValue($"/{AuthorizedRoute}", out OpenApiPathItem path));
+                        Assert.NotNull(path);
+                        Assert.NotNull(path.Operations);
+                        Assert.True(path.Operations.TryGetValue(OperationType.Get, out OpenApiOperation operation));
+                        Assert.NotNull(operation);
+                        Assert.NotNull(operation.Responses);
+                        Assert.Contains(operation.Responses, r => r.Key == "401");
+                        Assert.Contains(operation.Responses, r => r.Key == "403");
+                    }
                 }
             }
         }
@@ -72,12 +88,24 @@ namespace Arcus.Templates.Tests.Integration.Swagger.v1
                     // Assert
                     Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-                    string swaggerJson = await response.Content.ReadAsStringAsync();
-                    JObject swagger = JObject.Parse(swaggerJson);
-                    var responses = swagger["paths"][$"/{AuthorizedAndNoneAuthorizedController.NoneAuthorizedRoute}"]["get"]["responses"].Children<JProperty>();
-                
-                    Assert.DoesNotContain(responses, r => r.Name == "401");
-                    Assert.DoesNotContain(responses, r => r.Name == "403");
+                    using (Stream swaggerJson = await response.Content.ReadAsStreamAsync())
+                    {
+                        var streamReader = new OpenApiStreamReader();
+                        OpenApiDocument openApiDoc = streamReader.Read(swaggerJson, out OpenApiDiagnostic diagnostic);
+                        IEnumerable<string> errors = diagnostic.Errors.Select(err => err.Message);
+                        _outputWriter.WriteLine(String.Join(", ", errors));
+
+                        Assert.NotNull(openApiDoc);
+                        Assert.NotNull(openApiDoc.Paths);
+                        Assert.True(openApiDoc.Paths.TryGetValue($"/{NoneAuthorizedRoute}", out OpenApiPathItem path));
+                        Assert.NotNull(path);
+                        Assert.NotNull(path.Operations);
+                        Assert.True(path.Operations.TryGetValue(OperationType.Get, out OpenApiOperation operation));
+                        Assert.NotNull(operation);
+                        Assert.NotNull(operation.Responses);
+                        Assert.DoesNotContain(operation.Responses, r => r.Key == "401");
+                        Assert.DoesNotContain(operation.Responses, r => r.Key == "403");
+                    }
                 }
             }
         }
@@ -97,12 +125,24 @@ namespace Arcus.Templates.Tests.Integration.Swagger.v1
                     // Assert
                     Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-                    string swaggerJson = await response.Content.ReadAsStringAsync();
-                    JObject swagger = JObject.Parse(swaggerJson);
-                    var responses = swagger["paths"][$"/{AuthorizedAndNoneAuthorizedController.AuthorizedRoute}"]["get"]["responses"].Children<JProperty>();
+                    using (Stream swaggerJson = await response.Content.ReadAsStreamAsync())
+                    {
+                        var streamReader = new OpenApiStreamReader();
+                        OpenApiDocument openApiDoc = streamReader.Read(swaggerJson, out OpenApiDiagnostic diagnostic);
+                        IEnumerable<string> errors = diagnostic.Errors.Select(err => err.Message);
+                        _outputWriter.WriteLine(String.Join(", ", errors));
 
-                    Assert.DoesNotContain(responses, r => r.Name == "401");
-                    Assert.DoesNotContain(responses, r => r.Name == "403");
+                        Assert.NotNull(openApiDoc);
+                        Assert.NotNull(openApiDoc.Paths);
+                        Assert.True(openApiDoc.Paths.TryGetValue($"/{AuthorizedRoute}", out OpenApiPathItem path));
+                        Assert.NotNull(path);
+                        Assert.NotNull(path.Operations);
+                        Assert.True(path.Operations.TryGetValue(OperationType.Get, out OpenApiOperation operation));
+                        Assert.NotNull(operation);
+                        Assert.NotNull(operation.Responses);
+                        Assert.DoesNotContain(operation.Responses, r => r.Key == "401");
+                        Assert.DoesNotContain(operation.Responses, r => r.Key == "403");
+                    }
                 }
             }
         }

--- a/src/Arcus.Templates.Tests.Integration/Swagger/v1/SwaggerDocAvailabilityTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/Swagger/v1/SwaggerDocAvailabilityTests.cs
@@ -30,7 +30,7 @@ namespace Arcus.Templates.Tests.Integration.Swagger.v1
             var configuration = TestConfig.Create(buildConfiguration);
             using (var project = await WebApiProject.StartNewAsync(configuration, _outputWriter)) 
             // Act
-            using (HttpResponseMessage response = await project.Swagger.GetSwaggerUI())
+            using (HttpResponseMessage response = await project.Swagger.GetSwaggerUIAsync())
             {
                 // Assert
                 Assert.NotNull(response);
@@ -47,7 +47,7 @@ namespace Arcus.Templates.Tests.Integration.Swagger.v1
             var configuration = TestConfig.Create(buildConfiguration);
             using (var project = await WebApiProject.StartNewAsync(configuration, _outputWriter))
             // Act
-            using (var response = await project.Swagger.GetSwaggerDocs())
+            using (var response = await project.Swagger.GetSwaggerDocsAsync())
             {
                 // Assert
                 Assert.NotNull(response);

--- a/src/Arcus.Templates.WebApi/.template.config/template.json
+++ b/src/Arcus.Templates.WebApi/.template.config/template.json
@@ -87,6 +87,16 @@
     "CertificateAuth": {
       "type": "computed",
       "value": "(authentication == \"Certificate\")"
+    },
+    "openapi-security-definitions": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Adds OAuth security definitions to authorized API operations in the Open API specification file"
+    },
+    "OpenApiSecurityDefinitions": {
+      "type": "computed",
+      "value": "(openapi-security-definitions == \"true\")"
     } 
   }
 }

--- a/src/Arcus.Templates.WebApi/Arcus.Templates.WebApi.csproj
+++ b/src/Arcus.Templates.WebApi/Arcus.Templates.WebApi.csproj
@@ -50,6 +50,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
     <PackageReference Include="Arcus.WebApi.Logging" Version="0.2" />
+    <PackageReference Include="Arcus.WebApi.OpenApi.Extensions" Version="0.2" Condition="'$(OpenApiSecurityDefinitions)' == 'true'"/>
     <PackageReference Include="Arcus.WebApi.Security.Authentication" Version="0.2" Condition="'$(Auth)' == 'true'" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="4.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="4.0.1" />

--- a/src/Arcus.Templates.WebApi/Startup.cs
+++ b/src/Arcus.Templates.WebApi/Startup.cs
@@ -24,6 +24,9 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Primitives;
 #endif
+#if OpenApiSecurityDefinitions
+using Arcus.WebApi.OpenApi.Extensions;
+#endif
 
 namespace Arcus.Templates.WebApi
 {
@@ -78,6 +81,9 @@ namespace Arcus.Templates.WebApi
             {
                 swaggerGenerationOptions.SwaggerDoc("v1", openApiInformation);
                 swaggerGenerationOptions.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, "Arcus.Templates.WebApi.Open-Api.xml"));
+#if OpenApiSecurityDefinitions
+                swaggerGenerationOptions.OperationFilter<OAuthAuthorizeOperationFilter>();
+#endif
             });
 //#endif
         }


### PR DESCRIPTION
A new project option is introduced to include the security responses to
authorized API endpoints.
This feature required to have an additional controller to be tested
correctly, which means the `WebApiProject` was slightly altered to have
the possibility to add fixture files after the project is created but
before it's started.