### PR TITLE
FEAT: configurable project template teardown

### DIFF
--- a/src/Arcus.Templates.Tests.Integration/Fixture/TearDownOptions.cs
+++ b/src/Arcus.Templates.Tests.Integration/Fixture/TearDownOptions.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace Arcus.Templates.Tests.Integration.Fixture
+{
+    /// <summary>
+    /// Configuration options to control how the <see cref="TemplateProject"/> implementation should tear down/dispose itself.
+    /// Note that these should only be used during development and not kept in the tests permanently.
+    /// </summary>
+    [Flags]
+    public enum TearDownOptions
+    {
+        /// <summary>
+        /// Default, removes all resources created for the <see cref="TemplateProject"/> so the environment is back to it's original state.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Keep the temporary created project directory on disk after the <see cref="TemplateProject"/> is disposed.
+        /// </summary>
+        KeepProjectDirectory = 1,
+
+        /// <summary>
+        /// Keep the created project running after the <see cref="TemplateProject"/> is disposed.
+        /// </summary>
+        KeepProjectRunning = 2,
+
+        /// <summary>
+        /// Keep the created project template installed after the <see cref="TemplateProject"/> is disposed.
+        /// </summary>
+        KeepProjectTemplateInstalled = 4
+    }
+}

--- a/src/Arcus.Templates.Tests.Integration/Fixture/TearDownOptions.cs
+++ b/src/Arcus.Templates.Tests.Integration/Fixture/TearDownOptions.cs
@@ -12,7 +12,7 @@ namespace Arcus.Templates.Tests.Integration.Fixture
         /// <summary>
         /// Default, removes all resources created for the <see cref="TemplateProject"/> so the environment is back to it's original state.
         /// </summary>
-        All = 0,
+        None = 0,
 
         /// <summary>
         /// Keep the temporary created project directory on disk after the <see cref="TemplateProject"/> is disposed.
@@ -22,7 +22,7 @@ namespace Arcus.Templates.Tests.Integration.Fixture
         /// <summary>
         /// Keep the created project running after the <see cref="TemplateProject"/> is disposed.
         /// </summary>
-        KeepProjectRunning = 2,
+        KeepProjectRunning = 3,
 
         /// <summary>
         /// Keep the created project template installed after the <see cref="TemplateProject"/> is disposed.

--- a/src/Arcus.Templates.Tests.Integration/Fixture/TearDownOptions.cs
+++ b/src/Arcus.Templates.Tests.Integration/Fixture/TearDownOptions.cs
@@ -12,7 +12,7 @@ namespace Arcus.Templates.Tests.Integration.Fixture
         /// <summary>
         /// Default, removes all resources created for the <see cref="TemplateProject"/> so the environment is back to it's original state.
         /// </summary>
-        None = 0,
+        All = 0,
 
         /// <summary>
         /// Keep the temporary created project directory on disk after the <see cref="TemplateProject"/> is disposed.

--- a/src/Arcus.Templates.Tests.Integration/Fixture/TemplateProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/Fixture/TemplateProject.cs
@@ -146,8 +146,8 @@ namespace Arcus.Templates.Tests.Integration.Fixture
             {
                 Policy.NoOp().ExecuteAndCapture(() => Disposing(true)),
                 RetryActionExceptWhen(TearDownOptions.KeepProjectRunning, StopProject),
-                RetryActionExceptWhen(TearDownOptions.KeepProjectTemplateInstalled, UninstallTemplate),
                 RetryActionExceptWhen(TearDownOptions.KeepProjectDirectory, DeleteProjectDirectory), 
+                RetryActionExceptWhen(TearDownOptions.KeepProjectTemplateInstalled, UninstallTemplate),
             };
 
             IEnumerable<Exception> exceptions = 
@@ -237,7 +237,7 @@ namespace Arcus.Templates.Tests.Integration.Fixture
             }
 
             return Policy.Timeout(TimeSpan.FromSeconds(30))
-                         .Wrap(Policy.Handle<IOException>()
+                         .Wrap(Policy.Handle<Exception>()
                                      .WaitAndRetryForever(_ => TimeSpan.FromSeconds(1)))
                          .ExecuteAndCapture(action);
         }

--- a/src/Arcus.Templates.Tests.Integration/Fixture/TestConfig.cs
+++ b/src/Arcus.Templates.Tests.Integration/Fixture/TestConfig.cs
@@ -14,12 +14,14 @@ namespace Arcus.Templates.Tests.Integration.Fixture
     {
         private readonly IConfigurationRoot _configuration;
 
-        private TestConfig(IConfigurationRoot configuration, BuildConfiguration buildConfiguration)
+        private TestConfig(IConfigurationRoot configuration, BuildConfiguration buildConfiguration, TearDownOptions tearDownOptions)
         {
             Guard.NotNull(configuration, nameof(configuration));
 
             _configuration = configuration;
+
             BuildConfiguration = buildConfiguration;
+            TearDownOptions = tearDownOptions;
         }
 
         /// <summary>
@@ -28,10 +30,18 @@ namespace Arcus.Templates.Tests.Integration.Fixture
         public BuildConfiguration BuildConfiguration { get; }
 
         /// <summary>
+        /// Gets the tear down options for the project created from the template.
+        /// </summary>
+        public TearDownOptions TearDownOptions { get; }
+
+        /// <summary>
         /// Creates a new <see cref="IConfigurationRoot"/> with test values.
         /// </summary>
         /// <param name="buildConfiguration">The configuration in which the created project from the template should be build.</param>
-        public static TestConfig Create(BuildConfiguration buildConfiguration = BuildConfiguration.Debug)
+        /// <param name="tearDownOptions">The options to control the tear down process for the created project from the template.</param>
+        public static TestConfig Create(
+            BuildConfiguration buildConfiguration = BuildConfiguration.Debug, 
+            TearDownOptions tearDownOptions = TearDownOptions.All)
         {
             var configuration = new ConfigurationBuilder()
                 .AddJsonFile(path: "appsettings.json", optional: true)
@@ -39,7 +49,7 @@ namespace Arcus.Templates.Tests.Integration.Fixture
                 .AddEnvironmentVariables()
                 .Build();
 
-            return new TestConfig(configuration, buildConfiguration);
+            return new TestConfig(configuration, buildConfiguration, tearDownOptions);
         }
 
         /// <summary>

--- a/src/Arcus.Templates.Tests.Integration/Fixture/TestConfig.cs
+++ b/src/Arcus.Templates.Tests.Integration/Fixture/TestConfig.cs
@@ -14,14 +14,13 @@ namespace Arcus.Templates.Tests.Integration.Fixture
     {
         private readonly IConfigurationRoot _configuration;
 
-        private TestConfig(IConfigurationRoot configuration, BuildConfiguration buildConfiguration, TearDownOptions tearDownOptions)
+        private TestConfig(IConfigurationRoot configuration, BuildConfiguration buildConfiguration)
         {
             Guard.NotNull(configuration, nameof(configuration));
 
             _configuration = configuration;
 
             BuildConfiguration = buildConfiguration;
-            TearDownOptions = tearDownOptions;
         }
 
         /// <summary>
@@ -30,18 +29,10 @@ namespace Arcus.Templates.Tests.Integration.Fixture
         public BuildConfiguration BuildConfiguration { get; }
 
         /// <summary>
-        /// Gets the tear down options for the project created from the template.
-        /// </summary>
-        public TearDownOptions TearDownOptions { get; }
-
-        /// <summary>
         /// Creates a new <see cref="IConfigurationRoot"/> with test values.
         /// </summary>
         /// <param name="buildConfiguration">The configuration in which the created project from the template should be build.</param>
-        /// <param name="tearDownOptions">The options to control the tear down process for the created project from the template.</param>
-        public static TestConfig Create(
-            BuildConfiguration buildConfiguration = BuildConfiguration.Debug, 
-            TearDownOptions tearDownOptions = TearDownOptions.All)
+        public static TestConfig Create(BuildConfiguration buildConfiguration = BuildConfiguration.Debug)
         {
             var configuration = new ConfigurationBuilder()
                 .AddJsonFile(path: "appsettings.json", optional: true)
@@ -49,7 +40,7 @@ namespace Arcus.Templates.Tests.Integration.Fixture
                 .AddEnvironmentVariables()
                 .Build();
 
-            return new TestConfig(configuration, buildConfiguration, tearDownOptions);
+            return new TestConfig(configuration, buildConfiguration);
         }
 
         /// <summary>

--- a/src/Arcus.Templates.Tests.Integration/Fixture/WebApiProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/Fixture/WebApiProject.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -7,6 +8,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Arcus.Templates.Tests.Integration.Health;
 using Arcus.Templates.Tests.Integration.Swagger;
+using Flurl;
 using GuardNet;
 using Polly;
 using Xunit.Abstractions;
@@ -16,6 +18,7 @@ namespace Arcus.Templates.Tests.Integration.Fixture
     /// <summary>
     /// Project template to create new web API projects.
     /// </summary>
+    [DebuggerDisplay("Project = {ProjectDirectory.FullName}, URL = {_baseUrl}")]
     public class WebApiProject : TemplateProject
     {
         private readonly Uri _baseUrl;
@@ -317,6 +320,15 @@ namespace Arcus.Templates.Tests.Integration.Fixture
             }
 
             return files.First().FullName;
+        }
+
+        /// <summary>
+        /// Returns a string that represents the current object.
+        /// </summary>
+        /// <returns>A string that represents the current object.</returns>
+        public override string ToString()
+        {
+            return $"Project: {ProjectDirectory.FullName}, running at: {_baseUrl.OriginalString.ResetToRoot()}";
         }
     }
 }


### PR DESCRIPTION
Make the tear down in the disposing of the temporary project, created from a template, configurable.
This configuration consists now with three options:
* `KeepProjectDirectory`: which makes sure that the temp folder is not removed when the test is done.
* `KeepProjectRunning`: which makes sure that the temp project is still running when the test is done.
* `KeepProjectTemplateInstalled`: which makes sure that the template used in the test is still installed after the test is done.

#### Keep in mind that these configuration options are only provided to help the developer when debugging/investigating in a problem with new or existing integration tests. It should not be used permenantly in the code; otherwise we can't garantee a clean environment after the test run; which can also lead to interacting tests problems.

> "With great strength comes great responsibility"

Closes #45 