### PR TITLE
Remove legacy for certificate auth & use latest versions of dependencies

### DIFF
--- a/src/Arcus.Templates.Tests.Integration/Arcus.Templates.Tests.Integration.csproj
+++ b/src/Arcus.Templates.Tests.Integration/Arcus.Templates.Tests.Integration.csproj
@@ -24,16 +24,19 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Arcus.WebApi.Security.Authentication" Version="0.2" />
+    <PackageReference Include="Arcus.WebApi.Security.Authentication" Version="0.3.0" />
     <PackageReference Include="BouncyCastle" Version="1.8.5" />
     <PackageReference Include="BouncyCastle.NetCoreSdk" Version="1.9.0.1" />
     <PackageReference Include="Flurl.Http" Version="2.4.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Polly" Version="7.1.1" />
     <PackageReference Include="System.Web.Http" Version="4.0.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/Arcus.Templates.Tests.Integration/Fixture/TemplateProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/Fixture/TemplateProject.cs
@@ -35,7 +35,7 @@ namespace Arcus.Templates.Tests.Integration.Fixture
             _outputWriter = outputWriter;
 
             string tempDirectoryPath = Path.Combine(Path.GetTempPath(), $"{ProjectName}-{Guid.NewGuid()}");
-            ProjectDirectory = new DirectoryInfo(tempDirectoryPath);;
+            ProjectDirectory = new DirectoryInfo(tempDirectoryPath);
             FixtureDirectory = fixtureDirectory;
         }
 
@@ -43,7 +43,7 @@ namespace Arcus.Templates.Tests.Integration.Fixture
         /// Gets the directory where the fixtures are located that are used when a project requires additional functionality.
         /// </summary>
         protected DirectoryInfo FixtureDirectory { get; }
-        
+
         /// <summary>
         /// Gets the directory where a new project is created from the template.
         /// </summary>
@@ -69,7 +69,7 @@ namespace Arcus.Templates.Tests.Integration.Fixture
 
             string shortName = GetTemplateShortNameAtTemplateFolder();
             _outputWriter.WriteLine($"Creates new project from template {shortName} at {ProjectDirectory.FullName}");
-            
+
             RunDotNet($"new -i {_templateDirectory.FullName}");
 
             string commandArguments = projectOptions.ToCommandLineArguments();
@@ -114,7 +114,7 @@ namespace Arcus.Templates.Tests.Integration.Fixture
 
             string targetAssembly = Path.Combine(ProjectDirectory.FullName, $"bin/{buildConfiguration}/netcoreapp2.2/{ProjectName}.dll");
             string runCommand = $"exec {targetAssembly} {commandArguments ?? String.Empty}";
-            
+
             _outputWriter.WriteLine("> dotnet {0}", runCommand);
             var processInfo = new ProcessStartInfo("dotnet", runCommand)
             {
@@ -142,15 +142,15 @@ namespace Arcus.Templates.Tests.Integration.Fixture
             _disposed = true;
             LogTearDownAction();
 
-            PolicyResult[] results = 
+            PolicyResult[] results =
             {
                 Policy.NoOp().ExecuteAndCapture(() => Disposing(true)),
                 RetryActionExceptWhen(TearDownOptions.KeepProjectRunning, StopProject),
-                RetryActionExceptWhen(TearDownOptions.KeepProjectDirectory, DeleteProjectDirectory), 
+                RetryActionExceptWhen(TearDownOptions.KeepProjectDirectory, DeleteProjectDirectory),
                 RetryActionExceptWhen(TearDownOptions.KeepProjectTemplateInstalled, UninstallTemplate),
             };
 
-            IEnumerable<Exception> exceptions = 
+            IEnumerable<Exception> exceptions =
                 results.Where(result => result.Outcome == OutcomeType.Failure)
                        .Select(result => result.FinalException);
 
@@ -188,7 +188,7 @@ namespace Arcus.Templates.Tests.Integration.Fixture
             {
                 _process.Kill();
             }
-            
+
             _process.Dispose();
         }
 
@@ -237,7 +237,7 @@ namespace Arcus.Templates.Tests.Integration.Fixture
             }
 
             return Policy.Timeout(TimeSpan.FromSeconds(30))
-                         .Wrap(Policy.Handle<Exception>()
+                         .Wrap(Policy.Handle<Exception>((exception) => exception is UnauthorizedAccessException == false)
                                      .WaitAndRetryForever(_ => TimeSpan.FromSeconds(1)))
                          .ExecuteAndCapture(action);
         }

--- a/src/Arcus.Templates.Tests.Integration/Fixture/TemplateProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/Fixture/TemplateProject.cs
@@ -237,7 +237,7 @@ namespace Arcus.Templates.Tests.Integration.Fixture
             }
 
             return Policy.Timeout(TimeSpan.FromSeconds(30))
-                         .Wrap(Policy.Handle<Exception>((exception) => exception is UnauthorizedAccessException == false)
+                         .Wrap(Policy.Handle<Exception>()
                                      .WaitAndRetryForever(_ => TimeSpan.FromSeconds(1)))
                          .ExecuteAndCapture(action);
         }

--- a/src/Arcus.Templates.WebApi/Arcus.Templates.WebApi.csproj
+++ b/src/Arcus.Templates.WebApi/Arcus.Templates.WebApi.csproj
@@ -56,7 +56,7 @@
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
-    <PackageReference Include="Arcus.WebApi.Logging" Version="0.2" />
+    <PackageReference Include="Arcus.WebApi.Logging" Version="0.3.0" />
     <PackageReference Include="Arcus.WebApi.Security.Authentication" Version="0.2" Condition="'$(Auth)' == 'true'" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="4.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="4.0.1" />

--- a/src/Arcus.Templates.WebApi/Arcus.Templates.WebApi.csproj
+++ b/src/Arcus.Templates.WebApi/Arcus.Templates.WebApi.csproj
@@ -57,7 +57,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
     <PackageReference Include="Arcus.WebApi.Logging" Version="0.3.0" />
-    <PackageReference Include="Arcus.WebApi.Security.Authentication" Version="0.2" Condition="'$(Auth)' == 'true'" />
+    <PackageReference Include="Arcus.WebApi.Security.Authentication" Version="0.3.0" Condition="'$(Auth)' == 'true'" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="4.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="4.0.1" />
   </ItemGroup>


### PR DESCRIPTION
- Remove legacy for certificate auth
- Use latest versions of dependencies, include Arcus Web API

Closes #58