### PR TITLE
CHORE: introduce integration category for Docker & SelfContaining tests

### DIFF
--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -41,39 +41,13 @@ stages:
         pool:
           vmImage: 'ubuntu-16.04'
         steps:
-          - powershell: |
-              $packageVersion = '$(Build.BuildNumber)';
-              Write-Host "Package manual trigger version = $(Package.Version.ManualTrigger)"
-              Write-Host "Build reason = $(Build.Reason)"
-              if('$(Build.Reason)' -eq 'PullRequest') {
-                  Write-Host "Overriding package version given it's a PR build"
-                  $pullRequestNumber= "$(System.PullRequest.PullRequestNumber)"
-                  Write-Host "PR Number = $pullRequestNumber"
-                  $dateFormat = Get-Date -UFormat "%Y%m%d"
-                  $packageVersion = "$dateFormat-PR-$pullRequestNumber"
-              } else {
-                  $packageVersion = "$packageVersion-$(Package.Version.ManualTrigger)"
-              }
-              Write-Host "Package version = $packageVersion"
-              Write-Host "##vso[task.setvariable variable=PackageVersion]$packageVersion"
-              $isFork = $Env:SYSTEM_PULLREQUEST_ISFORK
-              Write-Host "Is this a fork? $isFork"
-              if($isFork -eq $false) {
-                  Write-Host "##vso[build.updatebuildnumber]$packageVersion"
-              } else {
-                  # Details: https://developercommunity.visualstudio.com/content/problem/350007/build-from-github-pr-fork-error-tf400813-the-user-1.html
-                  Write-Host "Not changing the build number as this is not supported for forks for now."
-              }
-            displayName: 'Determine Package Version'
-          - task: DotNetCoreInstaller@0
-            displayName: 'Import .NET Core SDK ($(DotNet.Sdk.Version))'
-            inputs:
-              version: '$(DotNet.Sdk.Version)'
-          - task: DotNetCoreCLI@2
-            displayName: 'Compile'
-            inputs:
-              projects: 'src/*.sln'
-              arguments: '--configuration $(Build.Configuration)'
+          - template: nuget/determine-pr-version.yml@templates
+            parameters:
+              manualTriggerVersion: $(Package.Version.ManualTrigger)
+          - template: 'build/build-solution.yml@templates'
+            parameters:
+              dotnetSdkVersion: '$(DotNet.Sdk.Version)'
+              versionSuffix: '$(packageVersion)'
           - task: CopyFiles@2
             displayName: 'Copy build artifacts'
             inputs:
@@ -86,8 +60,8 @@ stages:
               targetPath: '$(Pipeline.Workspace)/templates'
               artifactName: Templates
 
-  - stage: IntegrationTests
-    displayName: Integration Tests
+  - stage: DockerIntegrationTests
+    displayName: Docker Integration Tests
     dependsOn: Build
     condition: succeeded()
     jobs:
@@ -131,29 +105,33 @@ stages:
               ports: '$(Http.Port):$(Http.Port)'
               envVars: |
                 ARCUS_HTTP_PORT=$(Http.Port)
-          - task: qetza.replacetokens.replacetokens-task.replacetokens@3
-            displayName: 'Replace integration test tokens'
-            inputs:
-              rootDirectory: 'src/$(Project).Tests.Integration/'
-              targetFiles: 'appsettings.json'
-              encoding: 'auto'
-              writeBOM: true
-              actionOnMissing: 'fail'
-              keepToken: false
-              tokenPrefix: '#{'
-              tokenSuffix: '}#'
-          - task: DotNetCoreCLI@2
-            displayName: 'Run integration tests'
-            inputs:
-              command: test
-              projects: 'src/**/$(Project).Tests.Integration.csproj'
-              arguments: '--configuration $(Build.Configuration)'
-              nobuild: true
-              publishTestResults: true
+          - template: test/run-integration-tests.yml@templates
+            parameters:
+              dotnetSdkVersion: '$(DotNet.Sdk.Version)'
+              projectName: '$(Project).Tests.Integration'
+              category: 'Docker'
+
+  - stage: SelfContainingIntegrationTests
+    displayName: Self-Containing Integration Tests
+    dependsOn: Build
+    condition: succeeded()
+    jobs:
+      - job: RunIntegrationTests
+        displayName: 'Run integration tests'
+        pool:
+          vmImage: 'ubuntu-16.04'
+        steps:
+          - template: test/run-integration-tests.yml@templates
+            parameters:
+              dotnetSdkVersion: '$(DotNet.Sdk.Version)'
+              projectName: '$(Project).Tests.Integration'
+              category: 'Integration'
 
   - stage: ReleaseToMyget
     displayName: 'Release to MyGet'
-    dependsOn: IntegrationTests
+    dependsOn:
+      - DockerIntegrationTests
+      - SelfContainingIntegrationTests
     condition: succeeded()
     jobs:
       - job: PushToMyGet

--- a/src/Arcus.Templates.Tests.Integration/Authentication/v1/CertificateAuthenticationOptionTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/Authentication/v1/CertificateAuthenticationOptionTests.cs
@@ -9,6 +9,7 @@ using Xunit.Abstractions;
 namespace Arcus.Templates.Tests.Integration.Authentication.v1
 {
     [Collection("Integration")]
+    [Trait("Category", TestTraits.Integration)]
     public class CertificateAuthenticationOptionTests
     {
         private readonly TestConfig _configuration;

--- a/src/Arcus.Templates.Tests.Integration/Authentication/v1/CertificateAuthenticationOptionTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/Authentication/v1/CertificateAuthenticationOptionTests.cs
@@ -8,7 +8,7 @@ using Xunit.Abstractions;
 
 namespace Arcus.Templates.Tests.Integration.Authentication.v1
 {
-    [Collection("Integration")]
+    [Collection(TestCollections.Integration)]
     [Trait("Category", TestTraits.Integration)]
     public class CertificateAuthenticationOptionTests
     {

--- a/src/Arcus.Templates.Tests.Integration/Authentication/v1/SharedAccessKeyAuthenticationOptionTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/Authentication/v1/SharedAccessKeyAuthenticationOptionTests.cs
@@ -9,7 +9,7 @@ using static Arcus.Templates.Tests.Integration.Fixture.InMemorySecretProvider;
 
 namespace Arcus.Templates.Tests.Integration.Authentication.v1
 {
-    [Collection("Integration")]
+    [Collection(TestCollections.Integration)]
     [Trait("Category", TestTraits.Integration)]
     public class SharedAccessKeyAuthenticationOptionTests
     {


### PR DESCRIPTION
Uses the integration test YAML template which takes in a category. This allows us to split the 'Docker' integration tests from the 'Self-Containing' integration tests; making our CI build more correctly representing the test targets.

Closes #46 