### PR TITLE
NuGet: Use correct GitHub repo for pre-releases

### DIFF
--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -130,7 +130,7 @@ stages:
             displayName: 'Create GitHub Pre-Release (Conditional Step)'
             inputs:
               gitHubConnection: 'GitHub (arcus-automation - OAuth)'
-              repositoryName: 'azure-arcus/arcus.templates'
+              repositoryName: 'arcus-azure/arcus.templates'
               tagSource: manual
               tag: 'v$(Build.BuildNumber)'
               title: 'v$(Build.BuildNumber)'


### PR DESCRIPTION
NuGet: Use correct GitHub repo for pre-releases