### PR TITLE
FEAT: add service bus topic project template

### DIFF
--- a/src/Arcus.Templates.ServiceBus.Topic/.template.config/template.json
+++ b/src/Arcus.Templates.ServiceBus.Topic/.template.config/template.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json.schemastore.org/template",
+  "author": "Arcus",
+  "classifications": [
+    "Worker",
+    "Service Bus",
+    "Topic",
+    "BoilerPlate"
+  ],
+  "name": "Arcus Service Bus Topic",
+  "identity": "Arcus.Templates.ServiceBus.Topic",
+  "shortName": "arcus-servicebus-topic",
+  "sourceName": "Arcus.Templates.ServiceBus.Topic",
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "sources": [
+    {
+      "exclude": [
+        "**/[Bb]in/**",
+        "**/[Oo]bj/**",
+        ".template.config/**/*",
+        "**/*.filelist",
+        "**/*.user",
+        "**/*.lock.json",
+        "**/launchSettings.json"
+      ]
+    }
+  ],
+  "symbols": {
+    "AuthoringMode": {
+      "type": "generated",
+      "generator": "constant",
+      "parameters": {
+        "value": false
+      }
+    },
+    "ErrorDirective": {
+      "type": "generated",
+      "generator": "constant",
+      "parameters": {
+        "value": "#error"
+      },
+      "replaces": "//#error"
+    }
+  }
+}

--- a/src/Arcus.Templates.ServiceBus.Topic/Arcus.Templates.ServiceBus.Topic.csproj
+++ b/src/Arcus.Templates.ServiceBus.Topic/Arcus.Templates.ServiceBus.Topic.csproj
@@ -1,0 +1,58 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <!--#if (AuthoringMode)-->
+    <Authors>Arcus</Authors>
+    <Company>Arcus</Company>
+    <RepositoryType>Git</RepositoryType>
+    <Description>Provide a template to easily build workers on a Azure Service Bus Topic.</Description>
+    <IsPackable>true</IsPackable>
+    <PackageId>Arcus.Templates.ServiceBus.Topic</PackageId>
+    <Title>Template for worker Azure Service Bus Topic project</Title>
+    <PackageType>Template</PackageType>
+    <PackageTags>Worker;Azure;Azure;ServiceBus;Topic</PackageTags>
+    <Copyright>Copyright (c) Arcus</Copyright>
+    <PackageLicenseUrl>https://github.com/arcus-azure/arcus.templates/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/arcus-azure/arcus.templates</PackageProjectUrl>
+    <PackageTags>Worker;Azure;ServiceBus;Topic</PackageTags>
+    <RepositoryUrl>https://github.com/arcus-azure/arcus.templates</RepositoryUrl>
+    <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
+    <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <IncludeContentInPack>true</IncludeContentInPack>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <ContentTargetFolders>content</ContentTargetFolders>
+    <EnableDefaultContentItems>false</EnableDefaultContentItems>
+    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    <DockerComposeProjectPath>..\Arcus.Templates.Orchestrator.dcproj</DockerComposeProjectPath>
+    <!--#endif-->
+  </PropertyGroup>
+
+  <!--#if (AuthoringMode)-->
+  <ItemGroup>
+    <Content Include="**\*" Exclude="**\bin\**\*;**\obj\**\*;**\.vs\**\*;**\launchSettings.json" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="Dockerfile" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.7.12" />
+  </ItemGroup>
+  <!--#endif-->
+
+  <ItemGroup>
+    <PackageReference Include="Arcus.Messaging.Health" Version="0.1.0-preview-2" />
+    <PackageReference Include="Arcus.Messaging.Pumps.ServiceBus" Version="0.1.0-preview-2" />
+    <PackageReference Include="Guard.NET" Version="1.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.5" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+  </ItemGroup>
+</Project>

--- a/src/Arcus.Templates.ServiceBus.Topic/Dockerfile
+++ b/src/Arcus.Templates.ServiceBus.Topic/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.0.101-alpine3.9 AS base
+FROM mcr.microsoft.com/dotnet/core/sdk:3.0-alpine3.10 AS base
 WORKDIR /app
 EXPOSE 80
 

--- a/src/Arcus.Templates.ServiceBus.Topic/Dockerfile
+++ b/src/Arcus.Templates.ServiceBus.Topic/Dockerfile
@@ -1,0 +1,19 @@
+FROM mcr.microsoft.com/dotnet/core/sdk:3.0.101-alpine3.9 AS base
+WORKDIR /app
+EXPOSE 80
+
+FROM mcr.microsoft.com/dotnet/core/sdk:3.0.101-alpine3.9 AS build
+WORKDIR /src
+COPY ["Arcus.Templates.ServiceBus.Topic.csproj", ""]
+
+COPY . .
+WORKDIR "/src/."
+RUN dotnet build "Arcus.Templates.ServiceBus.Topic.csproj" -c Release -o /app
+
+FROM build AS publish
+RUN dotnet publish "Arcus.Templates.ServiceBus.Topic.csproj" -c Release -o /app
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app .
+ENTRYPOINT ["dotnet", "Arcus.Templates.ServiceBus.Topic.dll"]

--- a/src/Arcus.Templates.ServiceBus.Topic/Dockerfile
+++ b/src/Arcus.Templates.ServiceBus.Topic/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/core/sdk:3.0.101-alpine3.9 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/core/sdk:3.0.101-alpine3.9 AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:3.0-alpine3.10 AS build
 WORKDIR /src
 COPY ["Arcus.Templates.ServiceBus.Topic.csproj", ""]
 

--- a/src/Arcus.Templates.ServiceBus.Topic/Dockerfile
+++ b/src/Arcus.Templates.ServiceBus.Topic/Dockerfile
@@ -5,7 +5,6 @@ EXPOSE 80
 FROM mcr.microsoft.com/dotnet/core/sdk:3.0-alpine3.10 AS build
 WORKDIR /src
 COPY ["Arcus.Templates.ServiceBus.Topic.csproj", ""]
-
 COPY . .
 WORKDIR "/src/."
 RUN dotnet build "Arcus.Templates.ServiceBus.Topic.csproj" -c Release -o /app

--- a/src/Arcus.Templates.ServiceBus.Topic/EmptyMessage.cs
+++ b/src/Arcus.Templates.ServiceBus.Topic/EmptyMessage.cs
@@ -1,0 +1,9 @@
+﻿namespace Arcus.Templates.ServiceBus.Topic 
+{
+    /// <summary>
+    /// Temporary empty message type that the <see cref="EmptyMessagePump"/> processes.
+    /// </summary>
+    public class EmptyMessage
+    {
+    }
+}

--- a/src/Arcus.Templates.ServiceBus.Topic/EmptyMessagePump.cs
+++ b/src/Arcus.Templates.ServiceBus.Topic/EmptyMessagePump.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Arcus.Messaging.Abstractions;
+using Arcus.Messaging.Pumps.ServiceBus;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Arcus.Templates.ServiceBus.Topic
+{
+    /// <summary>
+    /// Empty implementation of the <see cref="AzureServiceBusMessagePump{TMessage}"/>, using an <see cref="object"/> as event message.
+    /// </summary>
+    public class EmptyMessagePump : AzureServiceBusMessagePump<EmptyMessage>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EmptyMessagePump"/> class.
+        /// </summary>
+        /// <param name="configuration">Configuration of the application</param>
+        /// <param name="serviceProvider">Collection of services that are configured</param>
+        /// <param name="logger">Logger to write telemetry to</param>
+        public EmptyMessagePump(IConfiguration configuration, IServiceProvider serviceProvider, ILogger<EmptyMessagePump> logger) 
+            : base(configuration, serviceProvider, logger)
+        {
+        }
+
+        /// <inheritdoc />
+        protected override async Task ProcessMessageAsync(
+            EmptyMessage message,
+            AzureServiceBusMessageContext messageContext,
+            MessageCorrelationInfo correlationInfo,
+            CancellationToken cancellationToken)
+        {
+            Logger.LogTrace("Processing message {message}...", message);
+
+            // Process message.
+
+            Logger.LogInformation("Message {message} processed!", message);
+        }
+    }
+}

--- a/src/Arcus.Templates.ServiceBus.Topic/Program.cs
+++ b/src/Arcus.Templates.ServiceBus.Topic/Program.cs
@@ -1,0 +1,34 @@
+﻿using Arcus.Security.Core;
+using Arcus.Security.Core.Caching;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Arcus.Templates.ServiceBus.Topic
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args)
+                .Build()
+                .Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureAppConfiguration(configuration =>
+                {
+                    configuration.AddCommandLine(args);
+                    configuration.AddEnvironmentVariables();
+                })
+                .ConfigureServices((hostContext, services) =>
+                {
+                    //#error Please provide a valid secret provider, for example Azure Key Vault: https: //security.arcus-azure.net/features/secrets/consume-from-key-vault
+                    services.AddSingleton<ISecretProvider>(serviceProvider => new CachedSecretProvider(secretProvider: null));
+
+                    services.AddServiceBusTopicMessagePump<EmptyMessagePump>("Receive-All", secretProvider => secretProvider.GetRawSecretAsync("ARCUS_SERVICEBUS_CONNECTIONSTRING"));
+                    services.AddTcpHealthProbes("ARCUS_HEALTH_PORT");
+                });
+    }
+}

--- a/src/Arcus.Templates.Tests.Integration/Fixture/TestConfig.cs
+++ b/src/Arcus.Templates.Tests.Integration/Fixture/TestConfig.cs
@@ -66,11 +66,19 @@ namespace Arcus.Templates.Tests.Integration.Fixture
         }
 
         /// <summary>
-        /// Gets the project directory of the ServiceBus Queue worker project.
+        /// Gets the project directory of the Service Bus Queue worker project.
         /// </summary>
         public DirectoryInfo GetServiceBusQueueProjectDirectory()
         {
             return PathCombineWithSourcesDirectory("Arcus.Templates.ServiceBus.Queue");
+        }
+
+        /// <summary>
+        /// Gets the project directory of the Service Bus Topic worker project.
+        /// </summary>
+        public DirectoryInfo GetServiceBusTopicProjectDirectory()
+        {
+            return PathCombineWithSourcesDirectory("Arcus.Templates.ServiceBus.Topic");
         }
 
         /// <summary>

--- a/src/Arcus.Templates.Tests.Integration/Fixture/TestConfig.cs
+++ b/src/Arcus.Templates.Tests.Integration/Fixture/TestConfig.cs
@@ -181,8 +181,8 @@ namespace Arcus.Templates.Tests.Integration.Fixture
         {
             switch (entity)
             {
-                case ServiceBusEntity.Queue: return this.GetValue<string>("Arcus:Worker:ServiceBus:ConnectionStringWithQueue");
-                case ServiceBusEntity.Topic: return this.GetValue<string>("Arcus:Worker:ServiceBus:ConnectionStringWithTopic");
+                case ServiceBusEntity.Queue: return _configuration["Arcus:Worker:ServiceBus:ConnectionStringWithQueue"];
+                case ServiceBusEntity.Topic: return _configuration["Arcus:Worker:ServiceBus:ConnectionStringWithTopic"];
                 default:
                     throw new ArgumentOutOfRangeException(nameof(entity), entity, "Unknown Service Bus entity");
             }

--- a/src/Arcus.Templates.Tests.Integration/Fixture/TestConfig.cs
+++ b/src/Arcus.Templates.Tests.Integration/Fixture/TestConfig.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Arcus.Templates.Tests.Integration.Worker;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Primitives;
 using GuardNet;
@@ -66,19 +67,17 @@ namespace Arcus.Templates.Tests.Integration.Fixture
         }
 
         /// <summary>
-        /// Gets the project directory of the Service Bus Queue worker project.
+        /// Gets the project directory of the Service Bus project based on the given <paramref name="entity"/>.
         /// </summary>
-        public DirectoryInfo GetServiceBusQueueProjectDirectory()
+        public DirectoryInfo GetServiceBusProjectDirectory(ServiceBusEntity entity)
         {
-            return PathCombineWithSourcesDirectory("Arcus.Templates.ServiceBus.Queue");
-        }
-
-        /// <summary>
-        /// Gets the project directory of the Service Bus Topic worker project.
-        /// </summary>
-        public DirectoryInfo GetServiceBusTopicProjectDirectory()
-        {
-            return PathCombineWithSourcesDirectory("Arcus.Templates.ServiceBus.Topic");
+            switch (entity)
+            {
+                case ServiceBusEntity.Queue: return PathCombineWithSourcesDirectory("Arcus.Templates.ServiceBus.Queue");
+                case ServiceBusEntity.Topic: return PathCombineWithSourcesDirectory("Arcus.Templates.ServiceBus.Topic");
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(entity), entity, "Unknown Service Bus entity");
+            }
         }
 
         /// <summary>
@@ -171,6 +170,22 @@ namespace Arcus.Templates.Tests.Integration.Fixture
             const string tcpPortKey = "Arcus:Worker:HealthPort";
 
             return _configuration.GetValue<int>(tcpPortKey);
+        }
+
+        /// <summary>
+        /// Gets the Service Bus connection string based on the given <paramref name="entity"/>.
+        /// </summary>
+        /// <param name="entity"></param>
+        /// <returns></returns>
+        public string GetServiceBusConnectionString(ServiceBusEntity entity)
+        {
+            switch (entity)
+            {
+                case ServiceBusEntity.Queue: return this.GetValue<string>("Arcus:Worker:ServiceBus:ConnectionStringWithQueue");
+                case ServiceBusEntity.Topic: return this.GetValue<string>("Arcus:Worker:ServiceBus:ConnectionStringWithTopic");
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(entity), entity, "Unknown Service Bus entity");
+            }
         }
 
         /// <summary>

--- a/src/Arcus.Templates.Tests.Integration/Worker/Health/TcpHealthProbeTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/Worker/Health/TcpHealthProbeTests.cs
@@ -20,7 +20,7 @@ namespace Arcus.Templates.Tests.Integration.Worker.Health
         public async Task MinimumServiceBusQueueWorker_ProbeForHealthReport_ResponseHealthy()
         {
             // Arrange
-            await using (var project = await ServiceBusQueueWorkerProject.StartNewAsync(_outputWriter))
+            await using (var project = await ServiceBusWorkerProject.StartNewWithQueueAsync(_outputWriter))
             {
                 // Act
                 HealthReport report = await project.Health.ProbeHealthReportAsync();

--- a/src/Arcus.Templates.Tests.Integration/Worker/MessagePump/MessagePumpService.cs
+++ b/src/Arcus.Templates.Tests.Integration/Worker/MessagePump/MessagePumpService.cs
@@ -60,9 +60,22 @@ namespace Arcus.Templates.Tests.Integration.Worker.MessagePump
         }
 
         /// <summary>
-        /// Simulate the message processing of the message pump.
+        /// Simulate the message processing of the message pump using the Service Bus Queue.
         /// </summary>
-        public async Task SimulateMessageProcessingAsync()
+        public async Task SimulateMessageProcessingWithQueueAsync()
+        {
+            await SimulateMessageProcessingAsync("Arcus:Worker:ServiceBus:ConnectionStringWithQueue");
+        }
+
+        /// <summary>
+        /// Simulate the message processing of the message pump using the Service Bus Topic.
+        /// </summary>
+        public async Task SimulateMessageProcessingWithTopicAsync()
+        {
+            await SimulateMessageProcessingAsync("Arcus:Worker:ServiceBus:ConnectionStringWithTopic");
+        }
+
+        private async Task SimulateMessageProcessingAsync(string connectionStringConfigurationKey)
         {
             if (_serviceBusEventConsumerHost is null)
             {
@@ -72,8 +85,8 @@ namespace Arcus.Templates.Tests.Integration.Worker.MessagePump
 
             var operationId = Guid.NewGuid().ToString();
             var transactionId = Guid.NewGuid().ToString();
-            
-            var connectionString = _configuration.GetValue<string>("Arcus:Worker:ServiceBus:ConnectionStringWithQueue");
+
+            var connectionString = _configuration.GetValue<string>(connectionStringConfigurationKey);
             var serviceBusConnectionStringBuilder = new ServiceBusConnectionStringBuilder(connectionString);
             var messageSender = new MessageSender(serviceBusConnectionStringBuilder);
 

--- a/src/Arcus.Templates.Tests.Integration/Worker/MessagePump/MessagePumpService.cs
+++ b/src/Arcus.Templates.Tests.Integration/Worker/MessagePump/MessagePumpService.cs
@@ -23,6 +23,7 @@ namespace Arcus.Templates.Tests.Integration.Worker.MessagePump
     /// </summary>
     public class MessagePumpService : IAsyncDisposable
     {
+        private readonly ServiceBusEntity _entity;
         private readonly ITestOutputHelper _outputWriter;
         private readonly TestConfig _configuration;
 
@@ -31,11 +32,12 @@ namespace Arcus.Templates.Tests.Integration.Worker.MessagePump
         /// <summary>
         /// Initializes a new instance of the <see cref="MessagePumpService"/> class.
         /// </summary>
-        public MessagePumpService(TestConfig configuration, ITestOutputHelper outputWriter)
+        public MessagePumpService(ServiceBusEntity entity, TestConfig configuration, ITestOutputHelper outputWriter)
         {
             Guard.NotNull(configuration, nameof(configuration));
             Guard.NotNull(outputWriter, nameof(outputWriter));
 
+            _entity = entity;
             _outputWriter = outputWriter;
             _configuration = configuration;
         }
@@ -60,22 +62,9 @@ namespace Arcus.Templates.Tests.Integration.Worker.MessagePump
         }
 
         /// <summary>
-        /// Simulate the message processing of the message pump using the Service Bus Queue.
+        /// Simulate the message processing of the message pump using the Service Bus.
         /// </summary>
-        public async Task SimulateMessageProcessingWithQueueAsync()
-        {
-            await SimulateMessageProcessingAsync("Arcus:Worker:ServiceBus:ConnectionStringWithQueue");
-        }
-
-        /// <summary>
-        /// Simulate the message processing of the message pump using the Service Bus Topic.
-        /// </summary>
-        public async Task SimulateMessageProcessingWithTopicAsync()
-        {
-            await SimulateMessageProcessingAsync("Arcus:Worker:ServiceBus:ConnectionStringWithTopic");
-        }
-
-        private async Task SimulateMessageProcessingAsync(string connectionStringConfigurationKey)
+        public async Task SimulateMessageProcessingAsync()
         {
             if (_serviceBusEventConsumerHost is null)
             {
@@ -86,7 +75,7 @@ namespace Arcus.Templates.Tests.Integration.Worker.MessagePump
             var operationId = Guid.NewGuid().ToString();
             var transactionId = Guid.NewGuid().ToString();
 
-            var connectionString = _configuration.GetValue<string>(connectionStringConfigurationKey);
+            var connectionString = _configuration.GetServiceBusConnectionString(_entity);
             var serviceBusConnectionStringBuilder = new ServiceBusConnectionStringBuilder(connectionString);
             var messageSender = new MessageSender(serviceBusConnectionStringBuilder);
 

--- a/src/Arcus.Templates.Tests.Integration/Worker/MessagePump/MessagePumpService.cs
+++ b/src/Arcus.Templates.Tests.Integration/Worker/MessagePump/MessagePumpService.cs
@@ -75,7 +75,7 @@ namespace Arcus.Templates.Tests.Integration.Worker.MessagePump
             var operationId = Guid.NewGuid().ToString();
             var transactionId = Guid.NewGuid().ToString();
 
-            var connectionString = _configuration.GetServiceBusConnectionString(_entity);
+            string connectionString = _configuration.GetServiceBusConnectionString(_entity);
             var serviceBusConnectionStringBuilder = new ServiceBusConnectionStringBuilder(connectionString);
             var messageSender = new MessageSender(serviceBusConnectionStringBuilder);
 

--- a/src/Arcus.Templates.Tests.Integration/Worker/ServiceBus/ServiceBusQueueMessagePumpTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/Worker/ServiceBus/ServiceBusQueueMessagePumpTests.cs
@@ -28,7 +28,7 @@ namespace Arcus.Templates.Tests.Integration.Worker.ServiceBus
             await using (var project = await ServiceBusWorkerProject.StartNewWithQueueAsync(_configuration, _outputWriter))
             {
                 // Act / Assert
-                await project.MessagePump.SimulateMessageProcessingAsync();
+                await project.MessagePump.SimulateMessageProcessingWithQueueAsync();
             }
         }
     }

--- a/src/Arcus.Templates.Tests.Integration/Worker/ServiceBus/ServiceBusQueueMessagePumpTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/Worker/ServiceBus/ServiceBusQueueMessagePumpTests.cs
@@ -28,7 +28,7 @@ namespace Arcus.Templates.Tests.Integration.Worker.ServiceBus
             await using (var project = await ServiceBusWorkerProject.StartNewWithQueueAsync(_configuration, _outputWriter))
             {
                 // Act / Assert
-                await project.MessagePump.SimulateMessageProcessingWithQueueAsync();
+                await project.MessagePump.SimulateMessageProcessingAsync();
             }
         }
     }

--- a/src/Arcus.Templates.Tests.Integration/Worker/ServiceBus/ServiceBusQueueMessagePumpTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/Worker/ServiceBus/ServiceBusQueueMessagePumpTests.cs
@@ -9,7 +9,6 @@ namespace Arcus.Templates.Tests.Integration.Worker.ServiceBus
     [Trait("Category", TestTraits.Integration)]
     public class ServiceBusQueueMessagePumpTests
     {
-        private readonly TestConfig _configuration;
         private readonly ITestOutputHelper _outputWriter;
 
         /// <summary>
@@ -17,7 +16,6 @@ namespace Arcus.Templates.Tests.Integration.Worker.ServiceBus
         /// </summary>
         public ServiceBusQueueMessagePumpTests(ITestOutputHelper outputWriter)
         {
-            _configuration = TestConfig.Create();
             _outputWriter = outputWriter;
         }
 
@@ -25,7 +23,7 @@ namespace Arcus.Templates.Tests.Integration.Worker.ServiceBus
         public async Task MinimServiceBusQueueWorker_PublishServiceBusMessage_MessageSuccessfullyProcessed()
         {
             // Arrange
-            await using (var project = await ServiceBusWorkerProject.StartNewWithQueueAsync(_configuration, _outputWriter))
+            await using (var project = await ServiceBusWorkerProject.StartNewWithQueueAsync(_outputWriter))
             {
                 // Act / Assert
                 await project.MessagePump.SimulateMessageProcessingAsync();

--- a/src/Arcus.Templates.Tests.Integration/Worker/ServiceBus/ServiceBusTopicMessagePumpTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/Worker/ServiceBus/ServiceBusTopicMessagePumpTests.cs
@@ -9,7 +9,6 @@ namespace Arcus.Templates.Tests.Integration.Worker.ServiceBus
     [Trait("Category", TestTraits.Integration)]
     public class ServiceBusTopicMessagePumpTests
     {
-        private readonly TestConfig _configuration;
         private readonly ITestOutputHelper _outputWriter;
 
         /// <summary>
@@ -17,7 +16,6 @@ namespace Arcus.Templates.Tests.Integration.Worker.ServiceBus
         /// </summary>
         public ServiceBusTopicMessagePumpTests(ITestOutputHelper outputWriter)
         {
-            _configuration = TestConfig.Create();
             _outputWriter = outputWriter;
         }
 
@@ -25,7 +23,7 @@ namespace Arcus.Templates.Tests.Integration.Worker.ServiceBus
         public async Task MinimServiceBusQueueWorker_PublishServiceBusMessage_MessageSuccessfullyProcessed()
         {
             // Arrange
-            await using (var project = await ServiceBusWorkerProject.StartNewWithTopicAsync(_configuration, _outputWriter))
+            await using (var project = await ServiceBusWorkerProject.StartNewWithTopicAsync(_outputWriter))
             {
                 // Act / Assert
                 await project.MessagePump.SimulateMessageProcessingAsync();

--- a/src/Arcus.Templates.Tests.Integration/Worker/ServiceBus/ServiceBusTopicMessagePumpTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/Worker/ServiceBus/ServiceBusTopicMessagePumpTests.cs
@@ -28,7 +28,7 @@ namespace Arcus.Templates.Tests.Integration.Worker.ServiceBus
             await using (var project = await ServiceBusWorkerProject.StartNewWithTopicAsync(_configuration, _outputWriter))
             {
                 // Act / Assert
-                await project.MessagePump.SimulateMessageProcessingWithTopicAsync();
+                await project.MessagePump.SimulateMessageProcessingAsync();
             }
         }
     }

--- a/src/Arcus.Templates.Tests.Integration/Worker/ServiceBus/ServiceBusTopicMessagePumpTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/Worker/ServiceBus/ServiceBusTopicMessagePumpTests.cs
@@ -7,7 +7,7 @@ namespace Arcus.Templates.Tests.Integration.Worker.ServiceBus
 {
     [Collection(TestCollections.Integration)]
     [Trait("Category", TestTraits.Integration)]
-    public class ServiceBusQueueMessagePumpTests
+    public class ServiceBusTopicMessagePumpTests
     {
         private readonly TestConfig _configuration;
         private readonly ITestOutputHelper _outputWriter;
@@ -15,7 +15,7 @@ namespace Arcus.Templates.Tests.Integration.Worker.ServiceBus
         /// <summary>
         /// Initializes a new instance of the <see cref="ServiceBusQueueMessagePumpTests"/> class.
         /// </summary>
-        public ServiceBusQueueMessagePumpTests(ITestOutputHelper outputWriter)
+        public ServiceBusTopicMessagePumpTests(ITestOutputHelper outputWriter)
         {
             _configuration = TestConfig.Create();
             _outputWriter = outputWriter;
@@ -25,10 +25,10 @@ namespace Arcus.Templates.Tests.Integration.Worker.ServiceBus
         public async Task MinimServiceBusQueueWorker_PublishServiceBusMessage_MessageSuccessfullyProcessed()
         {
             // Arrange
-            await using (var project = await ServiceBusWorkerProject.StartNewWithQueueAsync(_configuration, _outputWriter))
+            await using (var project = await ServiceBusWorkerProject.StartNewWithTopicAsync(_configuration, _outputWriter))
             {
                 // Act / Assert
-                await project.MessagePump.SimulateMessageProcessingAsync();
+                await project.MessagePump.SimulateMessageProcessingWithTopicAsync();
             }
         }
     }

--- a/src/Arcus.Templates.Tests.Integration/Worker/ServiceBusEntity.cs
+++ b/src/Arcus.Templates.Tests.Integration/Worker/ServiceBusEntity.cs
@@ -1,0 +1,11 @@
+﻿namespace Arcus.Templates.Tests.Integration.Worker 
+{
+    /// <summary>
+    /// Represents the different types of Service Bus project templates based on the available entities.
+    /// </summary>
+    public enum ServiceBusEntity
+    {
+        Queue, 
+        Topic
+    }
+}

--- a/src/Arcus.Templates.Tests.Integration/Worker/ServiceBusWorkerProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/Worker/ServiceBusWorkerProject.cs
@@ -97,7 +97,7 @@ namespace Arcus.Templates.Tests.Integration.Worker
             AddTypeAsFile<OrdersMessagePump>();
             AddTypeAsFile<SingleValueSecretProvider>();
 
-            var connectionString = _configuration.GetServiceBusConnectionString(_entity);
+            string connectionString = _configuration.GetServiceBusConnectionString(_entity);
             UpdateFileInProject("Program.cs", contents => 
                 RemoveCustomUserErrors(contents)
                     .Replace("EmptyMessagePump", nameof(OrdersMessagePump))

--- a/src/Arcus.Templates.Tests.Integration/appsettings.json
+++ b/src/Arcus.Templates.Tests.Integration/appsettings.json
@@ -10,7 +10,8 @@
         "AuthKey": "#{Arcus.TestInfra.EventGrid.Auth.Key}#"
       },
       "ServiceBus": {
-        "ConnectionStringWithQueue": "#{Arcus.ServiceBus.ConnectionStringWithQueue}#"
+        "ConnectionStringWithQueue": "#{Arcus.ServiceBus.ConnectionStringWithQueue}#",
+        "ConnectionStringWithTopic": "#{Arcus.ServiceBus.ConnectionStringWithTopic}#" 
       },
       "Infra": {
         "ServiceBus": {

--- a/src/Arcus.Templates.sln
+++ b/src/Arcus.Templates.sln
@@ -15,12 +15,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Arcus.Templates.ServiceBus.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Arcus.Templates.ServiceBus.Topic", "Arcus.Templates.ServiceBus.Topic\Arcus.Templates.ServiceBus.Topic.csproj", "{F4200B87-E88B-4DF3-8385-CAF357956D29}"
 EndProject
-Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Arcus.Templates.ServiceBus", "Arcus.Templates.ServiceBus\Arcus.Templates.ServiceBus.shproj", "{BF11423E-B32A-4632-9255-DDE5E1DCF38E}"
-EndProject
 Global
-	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		Arcus.Templates.ServiceBus\Arcus.Templates.ServiceBus.projitems*{bf11423e-b32a-4632-9255-dde5e1dcf38e}*SharedItemsImports = 13
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU

--- a/src/Arcus.Templates.sln
+++ b/src/Arcus.Templates.sln
@@ -11,9 +11,16 @@ Project("{E53339B2-1760-4266-BCC7-CA923CBCF16C}") = "Arcus.Templates.Orchestrato
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{F6DBEE21-816E-434F-AEA3-9FD6C2261E85}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Arcus.Templates.ServiceBus.Queue", "Arcus.Templates.ServiceBus.Queue\Arcus.Templates.ServiceBus.Queue.csproj", "{094D277F-AB55-4CD8-B346-4693796FABDA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Arcus.Templates.ServiceBus.Queue", "Arcus.Templates.ServiceBus.Queue\Arcus.Templates.ServiceBus.Queue.csproj", "{094D277F-AB55-4CD8-B346-4693796FABDA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Arcus.Templates.ServiceBus.Topic", "Arcus.Templates.ServiceBus.Topic\Arcus.Templates.ServiceBus.Topic.csproj", "{F4200B87-E88B-4DF3-8385-CAF357956D29}"
+EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Arcus.Templates.ServiceBus", "Arcus.Templates.ServiceBus\Arcus.Templates.ServiceBus.shproj", "{BF11423E-B32A-4632-9255-DDE5E1DCF38E}"
 EndProject
 Global
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		Arcus.Templates.ServiceBus\Arcus.Templates.ServiceBus.projitems*{bf11423e-b32a-4632-9255-dde5e1dcf38e}*SharedItemsImports = 13
+	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
@@ -35,6 +42,10 @@ Global
 		{094D277F-AB55-4CD8-B346-4693796FABDA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{094D277F-AB55-4CD8-B346-4693796FABDA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{094D277F-AB55-4CD8-B346-4693796FABDA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F4200B87-E88B-4DF3-8385-CAF357956D29}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F4200B87-E88B-4DF3-8385-CAF357956D29}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F4200B87-E88B-4DF3-8385-CAF357956D29}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F4200B87-E88B-4DF3-8385-CAF357956D29}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Provides a new project template `arcus-servicebus-topic` to create a project with a message pump on a Azure Service Bus Topic.

Relates to #11 