### PR TITLE
FEAT: provide opt-out of OpenApi docs with  project option

### DIFF
--- a/docs/features/web-api-template.md
+++ b/docs/features/web-api-template.md
@@ -37,8 +37,9 @@ And additional features available with options:
   * `SharedAccessKey`: adds [shared access key authentication](https://webapi.arcus-azure.net/features/security/auth/shared-access-key) mechanism to the API project
   * `Certificate`: adds [client certificate authentication](https://webapi.arcus-azure.net/features/security/auth/certificate) mechanism to the API project
   * `None`: no authentication configured on the API project.
-* `-ec|--exclude-correlation` (default `false`): excludes the [capability to correlate](https://webapi.arcus-azure.net/features/correlation) between HTTP requests/responses.
 * `-ia|--include-appsettings` (default `false`): includes a `appsettings.json` file to the web API project.
+* `-ec|--exclude-correlation` (default `false`): excludes the [capability to correlate](https://webapi.arcus-azure.net/features/correlation) between HTTP requests/responses from the API project.
+* `-eo|--exdlude-openApi` (default `false`): exclude the [ASP.NET Swagger docs generation and UI](https://docs.microsoft.com/en-us/aspnet/core/tutorials/getting-started-with-swashbuckle?view=aspnetcore-3.1&tabs=visual-studio) from API project.
 
 ## Security
 As part of this template the following HTTP header(s) are removed for security sake:

--- a/docs/features/web-api-template.md
+++ b/docs/features/web-api-template.md
@@ -39,7 +39,7 @@ And additional features available with options:
   * `None`: no authentication configured on the API project.
 * `-ia|--include-appsettings` (default `false`): includes a `appsettings.json` file to the web API project.
 * `-ec|--exclude-correlation` (default `false`): excludes the [capability to correlate](https://webapi.arcus-azure.net/features/correlation) between HTTP requests/responses from the API project.
-* `-eo|--exdlude-openApi` (default `false`): exclude the [ASP.NET Swagger docs generation and UI](https://docs.microsoft.com/en-us/aspnet/core/tutorials/getting-started-with-swashbuckle?view=aspnetcore-3.1&tabs=visual-studio) from API project.
+* `-eo|--exclude-openApi` (default `false`): exclude the [ASP.NET Swagger docs generation and UI](https://docs.microsoft.com/en-us/aspnet/core/tutorials/getting-started-with-swashbuckle?view=aspnetcore-3.1&tabs=visual-studio) from API project.
 
 ## Security
 As part of this template the following HTTP header(s) are removed for security sake:

--- a/src/Arcus.Templates.Tests.Integration/WebApi/Swagger/v1/SwaggerDocAvailabilityTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/WebApi/Swagger/v1/SwaggerDocAvailabilityTests.cs
@@ -47,11 +47,45 @@ namespace Arcus.Templates.Tests.Integration.WebApi.Swagger.v1
             var configuration = TestConfig.Create(buildConfiguration);
             using (var project = await WebApiProject.StartNewAsync(configuration, _outputWriter))
             // Act
-            using (var response = await project.Swagger.GetSwaggerDocsAsync())
+            using (HttpResponseMessage response = await project.Swagger.GetSwaggerDocsAsync())
             {
                 // Assert
                 Assert.NotNull(response);
                 Assert.Equal(expectedStatusCode, response.StatusCode);
+            }
+        }
+
+        [Fact]
+        public async Task GetSwaggerUI_WithExcludeOpenApiProjectOption_ReturnsNotFound()
+        {
+            // Arrange
+            var options =
+                new WebApiProjectOptions().WithExcludeOpenApiDocs();
+
+            using (var project = await WebApiProject.StartNewAsync(options, _outputWriter))
+            // Act
+            using (HttpResponseMessage response = await project.Swagger.GetSwaggerUIAsync())
+            {
+                // Assert
+                Assert.NotNull(response);
+                Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+            }
+        }
+
+        [Fact]
+        public async Task GetSwaggerDocs_WithExcludeOpenApiProjectOption_ReturnsNotFound()
+        {
+            // Arrange
+            var options = 
+                new WebApiProjectOptions().WithExcludeOpenApiDocs();
+
+            using (var project = await WebApiProject.StartNewAsync(options, _outputWriter))
+            // Act
+            using (HttpResponseMessage response = await project.Swagger.GetSwaggerDocsAsync())
+            {
+                // Assert
+                Assert.NotNull(response);
+                Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
             }
         }
     }

--- a/src/Arcus.Templates.Tests.Integration/WebApi/WebApiProjectOptions.cs
+++ b/src/Arcus.Templates.Tests.Integration/WebApi/WebApiProjectOptions.cs
@@ -43,13 +43,23 @@ namespace Arcus.Templates.Tests.Integration.WebApi
         }
 
         /// <summary>
-        /// Adds the project option to add the correlation capability to the web API project.
+        /// Adds the project option to exclude the correlation capability to the web API project.
         /// </summary>
         public WebApiProjectOptions WithExcludeCorrelation()
         {
-            ProjectOptions optionsWithCorrelation = AddOption("--exclude-correlation");
+            ProjectOptions optionsWithExcludeCorrelation = AddOption("--exclude-correlation");
 
-            return new WebApiProjectOptions(optionsWithCorrelation);
+            return new WebApiProjectOptions(optionsWithExcludeCorrelation);
+        }
+
+        /// <summary>
+        /// Adds the project option to exclude the correlation capability to the web API project.
+        /// </summary>
+        public WebApiProjectOptions WithExcludeOpenApiDocs()
+        {
+            ProjectOptions optionsWithExcludeOpenApi = AddOption("--exclude-openApi");
+
+            return new WebApiProjectOptions(optionsWithExcludeOpenApi);
         }
 
         /// <summary>

--- a/src/Arcus.Templates.WebApi/.template.config/template.json
+++ b/src/Arcus.Templates.WebApi/.template.config/template.json
@@ -110,11 +110,21 @@
       "type": "parameter",
       "datatype": "bool",
       "defaultValue": "false",
-      "description": "Exclude the capability to correlate between HTTP requests/responses"
+      "description": "Exclude the capability to correlate between HTTP requests/responses from the API project"
     },
     "ExcludeCorrelation": {
       "type": "computed",
       "value": "exclude-correlation"
-    } 
+    },
+    "exclude-openApi": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Exclude the OpenApi docs, UI generation from XML docs from the web API project"
+    },
+    "ExcludeOpenApi": {
+      "type": "computed",
+      "value": "exclude-openApi"
+    }
   }
 }

--- a/src/Arcus.Templates.WebApi/Arcus.Templates.WebApi.csproj
+++ b/src/Arcus.Templates.WebApi/Arcus.Templates.WebApi.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <DocumentationFile>Arcus.Templates.WebApi.Open-Api.xml</DocumentationFile>
+    <GenerateDocumentationFile Condition="'$(ExcludeOpenApi)' == 'false'">true</GenerateDocumentationFile>
+    <DocumentationFile Condition="'$(ExcludeOpenApi)' == 'false'">Arcus.Templates.WebApi.Open-Api.xml</DocumentationFile>
     <!--#if (AuthoringMode)-->
     <Authors>Arcus</Authors>
     <Company>Arcus</Company>

--- a/src/Arcus.Templates.WebApi/Arcus.Templates.WebApi.csproj
+++ b/src/Arcus.Templates.WebApi/Arcus.Templates.WebApi.csproj
@@ -39,6 +39,7 @@
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);</DefineConstants>
     <ExcludeCorrelation>false</ExcludeCorrelation>
+    <ExcludeOpenApi>false</ExcludeOpenApi>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.7.12" />
@@ -60,8 +61,8 @@
     <PackageReference Include="Arcus.WebApi.Correlation" Version="20200121.10.0-preview" Condition="'$(ExcludeCorrelation)' == 'false'" />
     <PackageReference Include="Arcus.WebApi.Logging" Version="0.3.0" />
     <PackageReference Include="Arcus.WebApi.Security.Authentication" Version="0.3.0" Condition="'$(Auth)' == 'true'" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="4.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="4.0.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="4.0.1" Condition="'$(ExcludeOpenApi)' == 'false'" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="4.0.1" Condition="'$(ExcludeOpenApi)' == 'false'" />
   </ItemGroup>
 
   <PropertyGroup>	

--- a/src/Arcus.Templates.WebApi/Startup.cs
+++ b/src/Arcus.Templates.WebApi/Startup.cs
@@ -7,7 +7,10 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json.Converters;
+#if ExcludeOpenApi
+#else
 using Swashbuckle.AspNetCore.Swagger;
+#endif
 #if SharedAccessKeyAuth
 using Arcus.Security.Secrets.Core.Caching;
 using Arcus.Security.Secrets.Core.Interfaces;
@@ -70,7 +73,9 @@ namespace Arcus.Templates.WebApi
 #else
             services.AddCorrelation();
 #endif
-            
+
+#if ExcludeOpenApi
+#else
 //[#if DEBUG]
             var openApiInformation = new Info
             {
@@ -84,6 +89,7 @@ namespace Arcus.Templates.WebApi
                 swaggerGenerationOptions.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, "Arcus.Templates.WebApi.Open-Api.xml"));
             });
 //[#endif]
+#endif
         }
 
         private static void RestrictToJsonContentType(MvcOptions options)
@@ -123,6 +129,8 @@ namespace Arcus.Templates.WebApi
 #endif
             app.UseMvc();
 
+#if ExcludeOpenApi
+#else
 //[#if DEBUG]
             app.UseSwagger();
             app.UseSwaggerUI(swaggerUiOptions =>
@@ -131,6 +139,7 @@ namespace Arcus.Templates.WebApi
                 swaggerUiOptions.DocumentTitle = "Arcus.Templates.WebApi";
             });
 //[#endif]
+#endif
         }
     }
 }


### PR DESCRIPTION
Provide project option to opt-out of the OpenAPI Swagger docs and UI generation from XML docs.

Closes #82 