### PR TITLE
Fix - disable SSL in web API template to run Docker debug before HTTPS config

### DIFF
--- a/src/Arcus.Templates.WebApi/Properties/launchSettings.json
+++ b/src/Arcus.Templates.WebApi/Properties/launchSettings.json
@@ -1,7 +1,8 @@
 {
   "profiles": {
     "Docker": {
-      "commandName": "Docker"
+      "commandName": "Docker",
+      "useSSL": false
     }
   }
 }

--- a/src/Arcus.Templates.WebApi/Startup.cs
+++ b/src/Arcus.Templates.WebApi/Startup.cs
@@ -212,7 +212,7 @@ namespace Arcus.Templates.WebApi
             app.UseSerilogRequestLogging();
             
 #endif
-            #warning Please configure application with HTTPS transport layer security
+            #warning Please configure application with HTTPS transport layer security and set 'useSSL' in the Docker 'launchSettings.json' back to 'true'
 
 #if JwtAuth
             app.UseAuthentication();


### PR DESCRIPTION
Closes #156 