### PR TITLE
Feature - introduce secret store concept into templates

### DIFF
--- a/src/Arcus.Templates.ServiceBus.Queue/.template.config/template.json
+++ b/src/Arcus.Templates.ServiceBus.Queue/.template.config/template.json
@@ -36,6 +36,22 @@
         "value": false
       }
     },
+    "IfDebug": {
+      "type": "generated",
+      "generator": "constant",
+      "parameters": {
+        "value": "#if DEBUG"
+      },
+      "replaces": "//[#if DEBUG]"
+    },
+    "EndIf": {
+      "type": "generated",
+      "generator": "constant",
+      "parameters": {
+        "value": "#endif"
+      },
+      "replaces": "//[#endif]"
+    },
     "ErrorDirective": {
       "type": "generated",
       "generator": "constant",

--- a/src/Arcus.Templates.ServiceBus.Queue/Arcus.Templates.ServiceBus.Queue.csproj
+++ b/src/Arcus.Templates.ServiceBus.Queue/Arcus.Templates.ServiceBus.Queue.csproj
@@ -47,6 +47,7 @@
   <ItemGroup>
     <PackageReference Include="Arcus.Messaging.Health" Version="0.1.0" />
     <PackageReference Include="Arcus.Messaging.Pumps.ServiceBus" Version="0.1.0" />
+    <PackageReference Include="Arcus.Security.Core" Version="1.2.0-preview-1" />
     <PackageReference Include="Guard.NET" Version="1.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.3" />

--- a/src/Arcus.Templates.ServiceBus.Queue/Arcus.Templates.ServiceBus.Queue.csproj
+++ b/src/Arcus.Templates.ServiceBus.Queue/Arcus.Templates.ServiceBus.Queue.csproj
@@ -48,6 +48,7 @@
     <PackageReference Include="Arcus.Messaging.Health" Version="0.1.0" />
     <PackageReference Include="Arcus.Messaging.Pumps.ServiceBus" Version="0.1.0" />
     <PackageReference Include="Arcus.Security.Core" Version="1.2.0-preview-1" />
+    <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.2.0-preview-1" />
     <PackageReference Include="Guard.NET" Version="1.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/src/Arcus.Templates.ServiceBus.Queue/Program.cs
+++ b/src/Arcus.Templates.ServiceBus.Queue/Program.cs
@@ -65,7 +65,7 @@ namespace Arcus.Templates.ServiceBus.Queue
                        {
 //[#if DEBUG]
                            stores.AddConfiguration(config);
-                           //[#endif]
+//[#endif]
 
                            //#error Please provide a valid secret provider, for example Azure Key Vault: https: //security.arcus-azure.net/features/secrets/consume-from-key-vault
                            stores.AddAzureKeyVaultWithManagedServiceIdentity("https://your-keyvault-vault.azure.net/");

--- a/src/Arcus.Templates.ServiceBus.Queue/Program.cs
+++ b/src/Arcus.Templates.ServiceBus.Queue/Program.cs
@@ -63,8 +63,12 @@ namespace Arcus.Templates.ServiceBus.Queue
                        })
                        .ConfigureSecretStore((config, stores) =>
                        {
+//[#if DEBUG]
+                           stores.AddConfiguration(config);
+//[#endif]
+
                            //#error Please provide a valid secret provider, for example Azure Key Vault: https: //security.arcus-azure.net/features/secrets/consume-from-key-vault
-                           stores.AddProvider(secretProvider: null);
+                           // stores.AddAzureKeyVault(secretProvider: null);
                        })
 #if (ExcludeSerilog == false)
                        .UseSerilog(UpdateLoggerConfiguration)

--- a/src/Arcus.Templates.ServiceBus.Queue/Program.cs
+++ b/src/Arcus.Templates.ServiceBus.Queue/Program.cs
@@ -65,10 +65,10 @@ namespace Arcus.Templates.ServiceBus.Queue
                        {
 //[#if DEBUG]
                            stores.AddConfiguration(config);
-//[#endif]
+                           //[#endif]
 
                            //#error Please provide a valid secret provider, for example Azure Key Vault: https: //security.arcus-azure.net/features/secrets/consume-from-key-vault
-                           // stores.AddAzureKeyVault(secretProvider: null);
+                           stores.AddAzureKeyVaultWithManagedServiceIdentity("https://your-keyvault-vault.azure.net/");
                        })
 #if (ExcludeSerilog == false)
                        .UseSerilog(UpdateLoggerConfiguration)

--- a/src/Arcus.Templates.ServiceBus.Queue/Program.cs
+++ b/src/Arcus.Templates.ServiceBus.Queue/Program.cs
@@ -61,14 +61,16 @@ namespace Arcus.Templates.ServiceBus.Queue
                            configuration.AddCommandLine(args);
                            configuration.AddEnvironmentVariables();
                        })
+                       .ConfigureSecretStore((config, stores) =>
+                       {
+                           //#error Please provide a valid secret provider, for example Azure Key Vault: https: //security.arcus-azure.net/features/secrets/consume-from-key-vault
+                           stores.AddProvider(secretProvider: null);
+                       })
 #if (ExcludeSerilog == false)
                        .UseSerilog(UpdateLoggerConfiguration)
 #endif
                        .ConfigureServices((hostContext, services) =>
                        {
-                           //#error Please provide a valid secret provider, for example Azure Key Vault: https: //security.arcus-azure.net/features/secrets/consume-from-key-vault
-                           services.AddSingleton<ISecretProvider>(serviceProvider => new CachedSecretProvider(secretProvider: null));
-
                            services.AddServiceBusQueueMessagePump(secretProvider => secretProvider.GetRawSecretAsync("ARCUS_SERVICEBUS_CONNECTIONSTRING"))
                                    .WithServiceBusMessageHandler<EmptyMessageHandler, EmptyMessage>();
                            

--- a/src/Arcus.Templates.ServiceBus.Topic/.template.config/template.json
+++ b/src/Arcus.Templates.ServiceBus.Topic/.template.config/template.json
@@ -36,6 +36,22 @@
         "value": false
       }
     },
+    "IfDebug": {
+      "type": "generated",
+      "generator": "constant",
+      "parameters": {
+        "value": "#if DEBUG"
+      },
+      "replaces": "//[#if DEBUG]"
+    },
+    "EndIf": {
+      "type": "generated",
+      "generator": "constant",
+      "parameters": {
+        "value": "#endif"
+      },
+      "replaces": "//[#endif]"
+    },
     "ErrorDirective": {
       "type": "generated",
       "generator": "constant",

--- a/src/Arcus.Templates.ServiceBus.Topic/Arcus.Templates.ServiceBus.Topic.csproj
+++ b/src/Arcus.Templates.ServiceBus.Topic/Arcus.Templates.ServiceBus.Topic.csproj
@@ -47,6 +47,7 @@
   <ItemGroup>
     <PackageReference Include="Arcus.Messaging.Health" Version="0.1.0" />
     <PackageReference Include="Arcus.Messaging.Pumps.ServiceBus" Version="0.1.0" />
+    <PackageReference Include="Arcus.Security.Core" Version="1.2.0-preview-1" />
     <PackageReference Include="Guard.NET" Version="1.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.3" />

--- a/src/Arcus.Templates.ServiceBus.Topic/Arcus.Templates.ServiceBus.Topic.csproj
+++ b/src/Arcus.Templates.ServiceBus.Topic/Arcus.Templates.ServiceBus.Topic.csproj
@@ -48,6 +48,7 @@
     <PackageReference Include="Arcus.Messaging.Health" Version="0.1.0" />
     <PackageReference Include="Arcus.Messaging.Pumps.ServiceBus" Version="0.1.0" />
     <PackageReference Include="Arcus.Security.Core" Version="1.2.0-preview-1" />
+    <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.2.0-preview-1" />
     <PackageReference Include="Guard.NET" Version="1.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/src/Arcus.Templates.ServiceBus.Topic/Program.cs
+++ b/src/Arcus.Templates.ServiceBus.Topic/Program.cs
@@ -65,10 +65,10 @@ namespace Arcus.Templates.ServiceBus.Topic
                        {
 //[#if DEBUG]
                            stores.AddConfiguration(config);
-//[#endif]
+                           //[#endif]
 
                            //#error Please provide a valid secret provider, for example Azure Key Vault: https: //security.arcus-azure.net/features/secrets/consume-from-key-vault
-                           // stores.AddAzureKeyVault(secretProvider: null);
+                           stores.AddAzureKeyVaultWithManagedServiceIdentity("https://your-keyvault-vault.azure.net/");
                        })
 #if (ExcludeSerilog == false)
                        .UseSerilog(UpdateLoggerConfiguration)

--- a/src/Arcus.Templates.ServiceBus.Topic/Program.cs
+++ b/src/Arcus.Templates.ServiceBus.Topic/Program.cs
@@ -63,8 +63,12 @@ namespace Arcus.Templates.ServiceBus.Topic
                        })
                        .ConfigureSecretStore((config, stores) =>
                        {
+//[#if DEBUG]
+                           stores.AddConfiguration(config);
+//[#endif]
+
                            //#error Please provide a valid secret provider, for example Azure Key Vault: https: //security.arcus-azure.net/features/secrets/consume-from-key-vault
-                           stores.AddProvider(secretProvider: null);
+                           // stores.AddAzureKeyVault(secretProvider: null);
                        })
 #if (ExcludeSerilog == false)
                        .UseSerilog(UpdateLoggerConfiguration)

--- a/src/Arcus.Templates.ServiceBus.Topic/Program.cs
+++ b/src/Arcus.Templates.ServiceBus.Topic/Program.cs
@@ -61,14 +61,16 @@ namespace Arcus.Templates.ServiceBus.Topic
                            configuration.AddCommandLine(args);
                            configuration.AddEnvironmentVariables();
                        })
+                       .ConfigureSecretStore((config, stores) =>
+                       {
+                           //#error Please provide a valid secret provider, for example Azure Key Vault: https: //security.arcus-azure.net/features/secrets/consume-from-key-vault
+                           stores.AddProvider(secretProvider: null);
+                       })
 #if (ExcludeSerilog == false)
                        .UseSerilog(UpdateLoggerConfiguration)
 #endif
                        .ConfigureServices((hostContext, services) =>
                        {
-                           //#error Please provide a valid secret provider, for example Azure Key Vault: https: //security.arcus-azure.net/features/secrets/consume-from-key-vault
-                           services.AddSingleton<ISecretProvider>(serviceProvider => new CachedSecretProvider(secretProvider: null));
-
                            services.AddServiceBusTopicMessagePump("Receive-All", secretProvider => secretProvider.GetRawSecretAsync("ARCUS_SERVICEBUS_CONNECTIONSTRING"))
                                    .WithServiceBusMessageHandler<EmptyMessageHandler, EmptyMessage>();
                            

--- a/src/Arcus.Templates.Tests.Integration/Arcus.Templates.Tests.Integration.csproj
+++ b/src/Arcus.Templates.Tests.Integration/Arcus.Templates.Tests.Integration.csproj
@@ -30,7 +30,7 @@
   
   <ItemGroup>
     <PackageReference Include="Arcus.EventGrid.Publishing" Version="3.0.0" />
-    <PackageReference Include="Arcus.WebApi.Security.Authentication" Version="0.4.0" />
+    <PackageReference Include="Arcus.WebApi.Security" Version="1.0.1" />
     <PackageReference Include="Arcus.Messaging.Pumps.ServiceBus" Version="20200310.7.0-preview" />
     <PackageReference Include="Arcus.EventGrid.Testing" Version="3.0.0" />
     <PackageReference Include="Bogus" Version="29.0.2" />

--- a/src/Arcus.Templates.Tests.Integration/Fixture/InMemorySecretProvider.cs
+++ b/src/Arcus.Templates.Tests.Integration/Fixture/InMemorySecretProvider.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
-using Arcus.Security.Secrets.Core.Interfaces;
+using Arcus.Security.Core;
+using Arcus.Security.Core.Caching;
+using Arcus.Security.Core.Caching.Configuration;
 using GuardNet;
 
 namespace Arcus.Templates.Tests.Integration.Fixture
@@ -26,6 +27,11 @@ namespace Arcus.Templates.Tests.Integration.Fixture
         }
 
         /// <summary>
+        /// Gets the cache-configuration for this instance.
+        /// </summary>
+        public ICacheConfiguration Configuration { get; } = null;
+
+        /// <summary>
         /// Retrieves the secret value, based on the given name
         /// </summary>
         /// <param name="secretName">The name of the secret key</param>
@@ -33,22 +39,46 @@ namespace Arcus.Templates.Tests.Integration.Fixture
         /// <returns>Returns a <see cref="Task{TResult}"/> that contains the secret key</returns>
         /// <exception cref="ArgumentException">The name must not be empty</exception>
         /// <exception cref="ArgumentNullException">The name must not be null</exception>
-        public async Task<string> Get(string secretName, bool ignoreCache)
+        public async Task<string> GetRawSecretAsync(string secretName, bool ignoreCache)
         {
             Guard.NotNull(secretName, "Secret name cannot be 'null'");
 
-            string value = await Get(secretName);
+            string value = await GetRawSecretAsync(secretName);
             return value;
         }
 
-        /// <summary>
-        /// Retrieves the secret value, based on the given name
-        /// </summary>
+        /// <summary>Retrieves the secret value, based on the given name</summary>
         /// <param name="secretName">The name of the secret key</param>
-        /// <returns>Returns a <see cref="Task"/> that contains the secret key</returns>
-        /// <exception cref="ArgumentException">The name must not be empty</exception>
-        /// <exception cref="ArgumentNullException">The name must not be null</exception>
-        public Task<string> Get(string secretName)
+        /// <param name="ignoreCache">Indicates if the cache should be used or skipped</param>
+        /// <returns>Returns a <see cref="T:System.Threading.Tasks.Task`1" /> that contains the secret key</returns>
+        /// <exception cref="T:System.ArgumentException">The name must not be empty</exception>
+        /// <exception cref="T:System.ArgumentNullException">The name must not be null</exception>
+        /// <exception cref="T:Arcus.Security.Core.SecretNotFoundException">The secret was not found, using the given name</exception>
+        public async Task<Secret> GetSecretAsync(string secretName, bool ignoreCache)
+        {
+            string value = await GetRawSecretAsync(secretName);
+            return new Secret(value, version: "1.0.0");
+        }
+
+        /// <summary>Retrieves the secret value, based on the given name</summary>
+        /// <param name="secretName">The name of the secret key</param>
+        /// <returns>Returns a <see cref="T:Arcus.Security.Core.Secret" /> that contains the secret key</returns>
+        /// <exception cref="T:System.ArgumentException">The <paramref name="secretName" /> must not be empty</exception>
+        /// <exception cref="T:System.ArgumentNullException">The <paramref name="secretName" /> must not be null</exception>
+        /// <exception cref="T:Arcus.Security.Core.SecretNotFoundException">The secret was not found, using the given name</exception>
+        public async Task<Secret> GetSecretAsync(string secretName)
+        {
+            string value = await GetRawSecretAsync(secretName);
+            return new Secret(value, version: "1.0.0");
+        }
+
+        /// <summary>Retrieves the secret value, based on the given name</summary>
+        /// <param name="secretName">The name of the secret key</param>
+        /// <returns>Returns the secret key.</returns>
+        /// <exception cref="T:System.ArgumentException">The <paramref name="secretName" /> must not be empty</exception>
+        /// <exception cref="T:System.ArgumentNullException">The <paramref name="secretName" /> must not be null</exception>
+        /// <exception cref="T:Arcus.Security.Core.SecretNotFoundException">The secret was not found, using the given name</exception>
+        public Task<string> GetRawSecretAsync(string secretName)
         {
             Guard.NotNull(secretName, "Secret name cannot be 'null'");
 
@@ -58,6 +88,16 @@ namespace Arcus.Templates.Tests.Integration.Fixture
             }
 
             return Task.FromResult<string>(null);
+        }
+
+        /// <summary>
+        /// Removes the secret with the given <paramref name="secretName" /> from the cache;
+        /// so the next time <see cref="M:Arcus.Security.Core.Caching.CachedSecretProvider.GetSecretAsync(System.String)" /> is called, a new version of the secret will be added back to the cache.
+        /// </summary>
+        /// <param name="secretName">The name of the secret that should be removed from the cache.</param>
+        public Task InvalidateSecretAsync(string secretName)
+        {
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Arcus.Templates.Tests.Integration/Fixture/TemplateProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/Fixture/TemplateProject.cs
@@ -103,6 +103,20 @@ namespace Arcus.Templates.Tests.Integration.Fixture
         }
 
         /// <summary>
+        /// Removes the custom error lines from the file <paramref name="content"/> in the project.
+        /// </summary>
+        /// <param name="content">The contents to remove the error lines from.</param>
+        /// <returns>
+        ///     The content without any error lines.
+        /// </returns>
+        protected string RemovesUserErrorsFromContents(string content)
+        {
+            return content.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
+                          .Where(line => !line.Contains("#error"))
+                          .Aggregate((line1, line2) => line1 + Environment.NewLine + line2);
+        }
+
+        /// <summary>
         /// Add a package to the created project from the template.
         /// </summary>
         /// <param name="packageName">The name of the package.</param>

--- a/src/Arcus.Templates.Tests.Integration/WebApi/WebApiProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/WebApi/WebApiProject.cs
@@ -191,6 +191,7 @@ namespace Arcus.Templates.Tests.Integration.WebApi
             Uri baseUrl = configuration.CreateWebApiBaseUrl();
             var project = new WebApiProject(baseUrl, configuration, templateDirectory, fixtureDirectory, outputWriter);
             project.CreateNewProject(projectOptions);
+            project.UpdateFileInProject("Program.cs", contents => project.RemovesUserErrorsFromContents(contents));
 
             return project;
         }

--- a/src/Arcus.Templates.Tests.Integration/WebApi/WebApiProjectOptions.cs
+++ b/src/Arcus.Templates.Tests.Integration/WebApi/WebApiProjectOptions.cs
@@ -129,7 +129,7 @@ namespace Arcus.Templates.Tests.Integration.WebApi
                 "Program.cs", 
                 contents =>
                 {
-                    contents = InsertInMemorySecretProviderCode(contents, "secretProvider: null", "JwtSigningKey", key);
+                    contents = InsertInMemorySecretProviderCode(contents, "JwtSigningKey", key);
                     return RemoveCustomUserErrors(contents);
                 });
 
@@ -216,7 +216,7 @@ namespace Arcus.Templates.Tests.Integration.WebApi
 
         private static string InsertInMemorySecretProviderCode(string contents, string secretName, string secretValue)
         {
-            return InsertInMemorySecretProviderCode(contents, "secretProvider: null", secretName, secretValue);
+            return InsertInMemorySecretProviderCode(contents, "// stores.AddAzureKeyVault(secretProvider: null)", secretName, secretValue);
         }
 
         private static string InsertInMemorySecretProviderCode(string contents, string replacementToken, string secretName, string secretValue)

--- a/src/Arcus.Templates.Tests.Integration/WebApi/WebApiProjectOptions.cs
+++ b/src/Arcus.Templates.Tests.Integration/WebApi/WebApiProjectOptions.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Arcus.Security.Secrets.Core.Interfaces;
 using Arcus.Templates.Tests.Integration.Fixture;
 using GuardNet;
 
@@ -119,12 +118,19 @@ namespace Arcus.Templates.Tests.Integration.WebApi
             ReplaceProjectFileContent(
                 projectDirectory,
                 "Startup.cs",
-                startupContent =>
+                contents =>
                 {
-                    startupContent = InsertInMemorySecretProviderCode(startupContent, "secretProvider: null", "JwtSigningKey", key);
-                    startupContent = InsertInMemorySecretProviderCode(startupContent, "null", "JwtSigningKey", key);
+                    contents = InsertInMemorySecretProviderCode(contents, "null", "JwtSigningKey", key);
+                    return RemoveCustomUserErrors(contents);
+                });
 
-                    return RemoveCustomUserErrors(startupContent);
+            ReplaceProjectFileContent(
+                projectDirectory, 
+                "Program.cs", 
+                contents =>
+                {
+                    contents = InsertInMemorySecretProviderCode(contents, "secretProvider: null", "JwtSigningKey", key);
+                    return RemoveCustomUserErrors(contents);
                 });
 
             ReplaceProjectFileContent(
@@ -160,12 +166,15 @@ namespace Arcus.Templates.Tests.Integration.WebApi
             ReplaceProjectFileContent(
                 projectDirectory,
                 "Startup.cs",
-                startupContent =>
-                {
-                    startupContent = InsertInMemorySecretProviderCode(startupContent, secretName, secretValue);
-                    startupContent = InsertSharedAccessAuthenticationHeaderSecretPair(startupContent, requestHeader, secretName);
+                contents => InsertSharedAccessAuthenticationHeaderSecretPair(contents, requestHeader, secretName));
 
-                    return RemoveCustomUserErrors(startupContent);
+            ReplaceProjectFileContent(
+                projectDirectory,
+                "Program.cs",
+                contents =>
+                {
+                    contents = InsertInMemorySecretProviderCode(contents, secretName, secretValue);
+                    return RemoveCustomUserErrors(contents);
                 });
         }
 
@@ -205,18 +214,18 @@ namespace Arcus.Templates.Tests.Integration.WebApi
             return files.First().FullName;
         }
 
-        private static string InsertInMemorySecretProviderCode(string startupContent, string secretName, string secretValue)
+        private static string InsertInMemorySecretProviderCode(string contents, string secretName, string secretValue)
         {
-            return InsertInMemorySecretProviderCode(startupContent, "secretProvider: null", secretName, secretValue);
+            return InsertInMemorySecretProviderCode(contents, "secretProvider: null", secretName, secretValue);
         }
 
-        private static string InsertInMemorySecretProviderCode(string startupContent, string replacementToken, string secretName, string secretValue)
+        private static string InsertInMemorySecretProviderCode(string contents, string replacementToken, string secretName, string secretValue)
         {
             string newSecretProviderWithSecret = 
                 $"new {typeof(InMemorySecretProvider).FullName}("
                 + $"new {typeof(Dictionary<string, string>).Namespace}.{nameof(Dictionary<string, string>)}<string, string> {{ [\"{secretName}\"] = \"{secretValue}\" }})";
 
-            return startupContent.Replace(replacementToken, newSecretProviderWithSecret);
+            return contents.Replace(replacementToken, newSecretProviderWithSecret);
         }
 
         private static string InsertSharedAccessAuthenticationHeaderSecretPair(string startupContent, string requestHeader, string secretName)

--- a/src/Arcus.Templates.Tests.Integration/WebApi/WebApiProjectOptions.cs
+++ b/src/Arcus.Templates.Tests.Integration/WebApi/WebApiProjectOptions.cs
@@ -217,7 +217,7 @@ namespace Arcus.Templates.Tests.Integration.WebApi
         private static string InsertInMemorySecretStore(string contents, string secretName, string secretValue)
         {
             string newSecretProviderWithSecret = CreatesInMemorySecretProviderConstructor(secretName, secretValue);
-            return contents.Replace("// stores.AddAzureKeyVault(secretProvider: null)", $"stores.AddProvider({newSecretProviderWithSecret})");
+            return contents.Replace("AddAzureKeyVaultWithManagedServiceIdentity(\"https://your-keyvault-vault.azure.net/\")", $"AddProvider({newSecretProviderWithSecret})");
         }
 
         private static string InsertInMemorySecretProviderCode(string contents, string replacementToken, string secretName, string secretValue)

--- a/src/Arcus.Templates.Tests.Integration/Worker/ServiceBusWorkerProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/Worker/ServiceBusWorkerProject.cs
@@ -170,7 +170,7 @@ namespace Arcus.Templates.Tests.Integration.Worker
                 RemoveCustomUserErrors(contents)
                     .Replace("EmptyMessageHandler", nameof(OrdersMessageHandler))
                     .Replace("EmptyMessage", nameof(Order))
-                    .Replace("secretProvider: null", $"new {nameof(SingleValueSecretProvider)}(\"{connectionString}\")"));
+                    .Replace("// stores.AddAzureKeyVault(secretProvider: null)", $"stores.AddProvider(new {nameof(SingleValueSecretProvider)}(\"{connectionString}\"))"));
         }
 
         private static string RemoveCustomUserErrors(string content)

--- a/src/Arcus.Templates.Tests.Integration/Worker/ServiceBusWorkerProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/Worker/ServiceBusWorkerProject.cs
@@ -167,20 +167,12 @@ namespace Arcus.Templates.Tests.Integration.Worker
 
             string connectionString = _configuration.GetServiceBusConnectionString(_entity);
             UpdateFileInProject("Program.cs", contents => 
-                RemoveCustomUserErrors(contents)
+                RemovesUserErrorsFromContents(contents)
                     .Replace("EmptyMessageHandler", nameof(OrdersMessageHandler))
                     .Replace("EmptyMessage", nameof(Order))
                     .Replace("AddAzureKeyVaultWithManagedServiceIdentity(\"https://your-keyvault-vault.azure.net/\")", 
                              $"AddProvider(new {nameof(SingleValueSecretProvider)}(\"{connectionString}\"))"));
         }
-
-        private static string RemoveCustomUserErrors(string content)
-        {
-            return content.Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries)
-                          .Where(line => !line.Contains("#error"))
-                          .Aggregate((line1, line2) => line1 + Environment.NewLine + line2);
-        }
-
 
         private async Task StartAsync(ServiceBusWorkerProjectOptions options)
         {

--- a/src/Arcus.Templates.Tests.Integration/Worker/ServiceBusWorkerProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/Worker/ServiceBusWorkerProject.cs
@@ -170,7 +170,8 @@ namespace Arcus.Templates.Tests.Integration.Worker
                 RemoveCustomUserErrors(contents)
                     .Replace("EmptyMessageHandler", nameof(OrdersMessageHandler))
                     .Replace("EmptyMessage", nameof(Order))
-                    .Replace("// stores.AddAzureKeyVault(secretProvider: null)", $"stores.AddProvider(new {nameof(SingleValueSecretProvider)}(\"{connectionString}\"))"));
+                    .Replace("AddAzureKeyVaultWithManagedServiceIdentity(\"https://your-keyvault-vault.azure.net/\")", 
+                             $"AddProvider(new {nameof(SingleValueSecretProvider)}(\"{connectionString}\"))"));
         }
 
         private static string RemoveCustomUserErrors(string content)

--- a/src/Arcus.Templates.WebApi/Arcus.Templates.WebApi.csproj
+++ b/src/Arcus.Templates.WebApi/Arcus.Templates.WebApi.csproj
@@ -51,16 +51,17 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Arcus.Security.Core" Version="1.2.0-preview-1" />
+    <PackageReference Include="Arcus.WebApi.Logging" Version="1.0.1" />
+    <PackageReference Include="Arcus.WebApi.Security" Version="1.0.1" Condition="'$(Auth)' == 'true'" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="0.2.0" Condition="'$(Serilog)' == 'true'" />
     <PackageReference Include="Guard.NET" Version="1.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.3" Condition="'$(JwtAuth)' == 'true'" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.3" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
-    <PackageReference Include="Arcus.WebApi.Logging" Version="1.0.1" />
-    <PackageReference Include="Arcus.WebApi.Security.Authentication" Version="0.4.0" Condition="'$(Auth)' == 'true'" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" Condition="'$(Serilog)' == 'true'" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="0.2.0" Condition="'$(Serilog)' == 'true'" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" Condition="'$(ExcludeOpenApi)' == 'false'" />
     <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="5.1.1" Condition="'$(ExcludeOpenApi)' == 'false' and '$(ExcludeCorrelation)' == 'false'" />
   </ItemGroup>

--- a/src/Arcus.Templates.WebApi/Arcus.Templates.WebApi.csproj
+++ b/src/Arcus.Templates.WebApi/Arcus.Templates.WebApi.csproj
@@ -52,6 +52,7 @@
 
   <ItemGroup>
     <PackageReference Include="Arcus.Security.Core" Version="1.2.0-preview-1" />
+    <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.2.0-preview-1" />
     <PackageReference Include="Arcus.WebApi.Logging" Version="1.0.1" />
     <PackageReference Include="Arcus.WebApi.Security" Version="1.0.1" Condition="'$(Auth)' == 'true'" />
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="0.2.1" Condition="'$(Serilog)' == 'true'" />

--- a/src/Arcus.Templates.WebApi/Program.cs
+++ b/src/Arcus.Templates.WebApi/Program.cs
@@ -76,17 +76,15 @@ namespace Arcus.Templates.WebApi
             IHostBuilder webHostBuilder =
                 Host.CreateDefaultBuilder(args)
                     .ConfigureAppConfiguration(configBuilder => configBuilder.AddConfiguration(configuration))
-#if (SharedAccessKeyAuth || JwtAuth)
                     .ConfigureSecretStore((config, stores) =>
                     {
 //[#if DEBUG]
                         stores.AddConfiguration(config);
 //[#endif]
 
-                        #error Please provide a valid secret provider, for example Azure Key Vault: https://security.arcus-azure.net/features/secrets/consume-from-key-vault
+                        //#error Please provide a valid secret provider, for example Azure Key Vault: https://security.arcus-azure.net/features/secrets/consume-from-key-vault
                         stores.AddAzureKeyVaultWithManagedServiceIdentity("https://your-keyvault-vault.azure.net/");
                     })
-#endif
                     .ConfigureWebHostDefaults(webBuilder =>
                     {
                         webBuilder.ConfigureKestrel(kestrelServerOptions => kestrelServerOptions.AddServerHeader = false)

--- a/src/Arcus.Templates.WebApi/Program.cs
+++ b/src/Arcus.Templates.WebApi/Program.cs
@@ -84,7 +84,7 @@ namespace Arcus.Templates.WebApi
 //[#endif]
 
                         #error Please provide a valid secret provider, for example Azure Key Vault: https://security.arcus-azure.net/features/secrets/consume-from-key-vault
-                        // stores.AddAzureKeyVault(secretProvider: null);
+                        stores.AddAzureKeyVaultWithManagedServiceIdentity("https://your-keyvault-vault.azure.net/");
                     })
 #endif
                     .ConfigureWebHostDefaults(webBuilder =>

--- a/src/Arcus.Templates.WebApi/Program.cs
+++ b/src/Arcus.Templates.WebApi/Program.cs
@@ -84,7 +84,7 @@ namespace Arcus.Templates.WebApi
 //[#endif]
 
                         #error Please provide a valid secret provider, for example Azure Key Vault: https://security.arcus-azure.net/features/secrets/consume-from-key-vault
-                        stores.AddProvider(secretProvider: null);
+                        // stores.AddAzureKeyVault(secretProvider: null);
                     })
 #endif
                     .ConfigureWebHostDefaults(webBuilder =>

--- a/src/Arcus.Templates.WebApi/Program.cs
+++ b/src/Arcus.Templates.WebApi/Program.cs
@@ -76,6 +76,17 @@ namespace Arcus.Templates.WebApi
             IHostBuilder webHostBuilder =
                 Host.CreateDefaultBuilder(args)
                     .ConfigureAppConfiguration(configBuilder => configBuilder.AddConfiguration(configuration))
+#if (SharedAccessKeyAuth || JwtAuth)
+                    .ConfigureSecretStore((config, stores) =>
+                    {
+//[#if DEBUG]
+                        stores.AddConfiguration(config);
+//[#endif]
+
+                        #error Please provide a valid secret provider, for example Azure Key Vault: https://security.arcus-azure.net/features/secrets/consume-from-key-vault
+                        stores.AddProvider(secretProvider: null);
+                    })
+#endif
                     .ConfigureWebHostDefaults(webBuilder =>
                     {
                         webBuilder.ConfigureKestrel(kestrelServerOptions => kestrelServerOptions.AddServerHeader = false)

--- a/src/Arcus.Templates.WebApi/Startup.cs
+++ b/src/Arcus.Templates.WebApi/Startup.cs
@@ -24,8 +24,7 @@ using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.Filters;
 #endif
 #if SharedAccessKeyAuth
-using Arcus.Security.Secrets.Core.Caching;
-using Arcus.Security.Secrets.Core.Interfaces;
+using Arcus.Security.Core.Caching;
 using Arcus.WebApi.Security.Authentication.SharedAccessKey;
 #endif
 #if CertificateAuth
@@ -38,8 +37,8 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Primitives;
 #endif
 #if JwtAuth
-using Arcus.Security.Secrets.Core.Caching;
-using Arcus.Security.Secrets.Core.Interfaces;
+using Arcus.Security.Core;
+using Arcus.Security.Core.Caching;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.Authorization;
@@ -76,10 +75,6 @@ namespace Arcus.Templates.WebApi
         // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
         public void ConfigureServices(IServiceCollection services)
         {
-#if (SharedAccessKeyAuth || JwtAuth)
-            #error Please provide a valid secret provider, for example Azure Key Vault: https://security.arcus-azure.net/features/secrets/consume-from-key-vault
-            services.AddSingleton<ICachedSecretProvider>(serviceProvider => new CachedSecretProvider(secretProvider: null));
-#endif
 #if CertificateAuth
             var certificateAuthenticationConfig = 
                 new CertificateAuthenticationConfigBuilder()
@@ -129,7 +124,7 @@ namespace Arcus.Templates.WebApi
                     })
                     .AddJwtBearer(x =>
                     {
-                        string key = secretProvider.Get("JwtSigningKey").GetAwaiter().GetResult();
+                        string key = secretProvider.GetRawSecretAsync("JwtSigningKey").GetAwaiter().GetResult();
                         
                         x.SaveToken = true;
                         x.TokenValidationParameters = new TokenValidationParameters


### PR DESCRIPTION
Updates the web API template and both worker templates with using the secret stores instead of registering the `ISecretProvider` by themselves.
Plus add the `IConfiguration` to the stores when running in DEBUG.

Relates to #186 