### PR TITLE
Feature - remove the 'Arcus ...' prefix of the templates in VS

### DIFF
--- a/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/.template.config/ide.host.json
+++ b/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/.template.config/ide.host.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/vs-2017.3.host",
   "name": {
-    "text": "Arcus Azure Functions Databricks Job Metrics project template"
+    "text": "Azure Functions Databricks Job Metrics"
   },
   "description": {
     "text": "Provide a template to easily build an Azure Functions that reports the completed Databricks job runs as metrics."

--- a/src/Arcus.Templates.AzureFunctions.Http/.template.config/ide.host.json
+++ b/src/Arcus.Templates.AzureFunctions.Http/.template.config/ide.host.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/vs-2017.3.host",
   "name": {
-    "text": "Arcus Azure Functions HTTP project template"
+    "text": "Azure Functions HTTP"
   },
   "description": {
     "text": "Provide a template to easily build an Azure Functions that exposes an HTTP endpoint."

--- a/src/Arcus.Templates.ServiceBus.Queue/.template.config/ide.host.json
+++ b/src/Arcus.Templates.ServiceBus.Queue/.template.config/ide.host.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/vs-2017.3.host",
   "name": {
-    "text": "Arcus Azure Service Bus Queue project template"
+    "text": "Azure Service Bus Queue"
   },
   "description": {
     "text": "Provide a template to easily build workers on a Azure Service Bus Queue."

--- a/src/Arcus.Templates.ServiceBus.Topic/.template.config/ide.host.json
+++ b/src/Arcus.Templates.ServiceBus.Topic/.template.config/ide.host.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/vs-2017.3.host",
   "name": {
-    "text": "Arcus Azure Service Bus Topic project template"
+    "text": "Azure Service Bus Topic"
   },
   "description": {
     "text": "Provide a template to easily build workers on a Azure Service Bus Topic."

--- a/src/Arcus.Templates.WebApi/.template.config/ide.host.json
+++ b/src/Arcus.Templates.WebApi/.template.config/ide.host.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/vs-2017.3.host",
   "name": {
-    "text": "Arcus Web API project template"
+    "text": "Web API"
   },
   "description": {
     "text": "Provide a template to easily build Web APIs running in Azure."


### PR DESCRIPTION
Re-Closes #297 
Relates to #296 