### PR TITLE
Docs - remove unused version badge in web API feature docs

### DIFF
--- a/docs/features/web-api-template.md
+++ b/docs/features/web-api-template.md
@@ -24,8 +24,6 @@ When installed, the template can be created with shortname: `arcus-webapi`:
 
 Creates a starter web API project with by default configured:
 
-![](https://img.shields.io/badge/Latest%20version-v0.3-green?link=https://github.com/arcus-azure/arcus.templates/releases/tag/v0.3.0)
-
 * Provides basic health endpoint with [ASP.NET Core health checks](https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/health-checks?view=aspnetcore-2.2) with [OpenAPI support](https://www.codit.eu/blog/documenting-asp-net-core-health-checks-with-openapi/).
 * Docker building file.
 * Default console logger.

--- a/docs/preview/web-api-template.md
+++ b/docs/preview/web-api-template.md
@@ -24,8 +24,6 @@ When installed, the template can be created with shortname: `arcus-webapi`:
 
 Creates a starter web API project with by default configured:
 
-![](https://img.shields.io/badge/Latest%20version-v0.3-green?link=https://github.com/arcus-azure/arcus.templates/releases/tag/v0.3.0)
-
 * Provides basic health endpoint with [ASP.NET Core health checks](https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/health-checks?view=aspnetcore-2.2) with [OpenAPI support](https://www.codit.eu/blog/documenting-asp-net-core-health-checks-with-openapi/).
 * Docker building file.
 * Default console logger.

--- a/docs/v0.1/web-api-template.md
+++ b/docs/v0.1/web-api-template.md
@@ -23,8 +23,6 @@ When installed, the template can be created with shortname: `arcus-webapi`:
 
 Creates a starter web API project with by default configured:
 
-![](https://img.shields.io/badge/Available%20starting-v0.1-green?link=https://github.com/arcus-azure/arcus.templates/releases/tag/v0.1.0)
-
 * [Exception middleware](https://webapi.arcus-azure.net/features/logging) to log unhandled exceptions thrown during request processing.
 * Content negotiation that only supports `application/json`.
 * OpenAPI docs generation and UI (only available locally).

--- a/docs/v0.2/web-api-template.md
+++ b/docs/v0.2/web-api-template.md
@@ -24,8 +24,6 @@ When installed, the template can be created with shortname: `arcus-webapi`:
 
 Creates a starter web API project with by default configured:
 
-![](https://img.shields.io/badge/Latest%20version-v0.2-green?link=https://github.com/arcus-azure/arcus.templates/releases/tag/v0.2.0)
-
 * Provides basic health endpoint with [ASP.NET Core health checks](https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/health-checks?view=aspnetcore-2.2) with [OpenAPI support](https://www.codit.eu/blog/documenting-asp-net-core-health-checks-with-openapi/).
 * Docker building file.
 * Default console logger.

--- a/docs/v0.3/web-api-template.md
+++ b/docs/v0.3/web-api-template.md
@@ -24,8 +24,6 @@ When installed, the template can be created with shortname: `arcus-webapi`:
 
 Creates a starter web API project with by default configured:
 
-![](https://img.shields.io/badge/Latest%20version-v0.3-green?link=https://github.com/arcus-azure/arcus.templates/releases/tag/v0.3.0)
-
 * Provides basic health endpoint with [ASP.NET Core health checks](https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/health-checks?view=aspnetcore-2.2) with [OpenAPI support](https://www.codit.eu/blog/documenting-asp-net-core-health-checks-with-openapi/).
 * Docker building file.
 * Default console logger.

--- a/docs/v0.6/web-api-template.md
+++ b/docs/v0.6/web-api-template.md
@@ -24,8 +24,6 @@ When installed, the template can be created with shortname: `arcus-webapi`:
 
 Creates a starter web API project with by default configured:
 
-![](https://img.shields.io/badge/Latest%20version-v0.3-green?link=https://github.com/arcus-azure/arcus.templates/releases/tag/v0.3.0)
-
 * Provides basic health endpoint with [ASP.NET Core health checks](https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/health-checks?view=aspnetcore-2.2) with [OpenAPI support](https://www.codit.eu/blog/documenting-asp-net-core-health-checks-with-openapi/).
 * Docker building file.
 * Default console logger.


### PR DESCRIPTION
We don't use this version badge anymore.