### PR TITLE
Feature - use current Azure Key Vault extension to kickstart in project templates 

### DIFF
--- a/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/Startup.cs
+++ b/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/Startup.cs
@@ -1,4 +1,5 @@
-﻿using Arcus.Templates.AzureFunctions.Databricks.JobMetrics;
+﻿using Arcus.Security.Core.Caching.Configuration;
+using Arcus.Templates.AzureFunctions.Databricks.JobMetrics;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -6,7 +7,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Serilog;
 using Serilog.Configuration;
-using Serilog.Core;
 using Serilog.Events;
 
 [assembly: FunctionsStartup(typeof(Startup))]
@@ -35,8 +35,8 @@ namespace Arcus.Templates.AzureFunctions.Databricks.JobMetrics
 
                 stores.AddEnvironmentVariables();
 
-                //#error Please provide a valid secret provider, for example Azure Key Vault: https://security.arcus-azure.net/features/secrets/consume-from-key-vault
-                stores.AddAzureKeyVaultWithManagedServiceIdentity("https://your-keyvault.vault.azure.net/");
+                //#error Please provide a valid secret provider, for example Azure Key Vault: https://security.arcus-azure.net/features/secret-store/provider/key-vault
+                stores.AddAzureKeyVaultWithManagedIdentity("https://your-keyvault.vault.azure.net/", CacheConfiguration.Default);
             });
 
             var instrumentationKey = config.GetValue<string>("APPLICATIONINSIGHTS_INSTRUMENTATIONKEY");

--- a/src/Arcus.Templates.AzureFunctions.Http/Startup.cs
+++ b/src/Arcus.Templates.AzureFunctions.Http/Startup.cs
@@ -1,4 +1,5 @@
-﻿using Arcus.Templates.AzureFunctions.Http;
+﻿using Arcus.Security.Core.Caching.Configuration;
+using Arcus.Templates.AzureFunctions.Http;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -35,8 +36,8 @@ namespace Arcus.Templates.AzureFunctions.Http
 
                 stores.AddEnvironmentVariables();
 
-                //#error Please provide a valid secret provider, for example Azure Key Vault: https://security.arcus-azure.net/features/secrets/consume-from-key-vault
-                stores.AddAzureKeyVaultWithManagedServiceIdentity("https://your-keyvault.vault.azure.net/");
+                //#error Please provide a valid secret provider, for example Azure Key Vault: https://security.arcus-azure.net/features/secret-store/provider/key-vault
+                stores.AddAzureKeyVaultWithManagedIdentity("https://your-keyvault.vault.azure.net/", CacheConfiguration.Default);
             });
 
             var instrumentationKey = config.GetValue<string>("APPLICATIONINSIGHTS_INSTRUMENTATIONKEY");

--- a/src/Arcus.Templates.ServiceBus.Queue/Program.cs
+++ b/src/Arcus.Templates.ServiceBus.Queue/Program.cs
@@ -1,6 +1,5 @@
 ﻿using System;
-using Arcus.Security.Core;
-using Arcus.Security.Core.Caching;
+using Arcus.Security.Core.Caching.Configuration;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -67,8 +66,8 @@ namespace Arcus.Templates.ServiceBus.Queue
                            stores.AddConfiguration(config);
 //[#endif]
 
-                           //#error Please provide a valid secret provider, for example Azure Key Vault: https: //security.arcus-azure.net/features/secrets/consume-from-key-vault
-                           stores.AddAzureKeyVaultWithManagedServiceIdentity("https://your-keyvault.vault.azure.net/");
+                           //#error Please provide a valid secret provider, for example Azure Key Vault: https://security.arcus-azure.net/features/secret-store/provider/key-vault
+                           stores.AddAzureKeyVaultWithManagedIdentity("https://your-keyvault.vault.azure.net/", CacheConfiguration.Default);
                        })
 #if (ExcludeSerilog == false)
                        .UseSerilog(UpdateLoggerConfiguration)

--- a/src/Arcus.Templates.ServiceBus.Topic/Program.cs
+++ b/src/Arcus.Templates.ServiceBus.Topic/Program.cs
@@ -1,6 +1,5 @@
 ﻿using System;
-using Arcus.Security.Core;
-using Arcus.Security.Core.Caching;
+using Arcus.Security.Core.Caching.Configuration;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -67,8 +66,8 @@ namespace Arcus.Templates.ServiceBus.Topic
                            stores.AddConfiguration(config);
                            //[#endif]
 
-                           //#error Please provide a valid secret provider, for example Azure Key Vault: https: //security.arcus-azure.net/features/secrets/consume-from-key-vault
-                           stores.AddAzureKeyVaultWithManagedServiceIdentity("https://your-keyvault.vault.azure.net/");
+                           //#error Please provide a valid secret provider, for example Azure Key Vault: https://security.arcus-azure.net/features/secret-store/provider/key-vault
+                           stores.AddAzureKeyVaultWithManagedIdentity("https://your-keyvault.vault.azure.net/", CacheConfiguration.Default);
                        })
 #if (ExcludeSerilog == false)
                        .UseSerilog(UpdateLoggerConfiguration)

--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/Databricks/JobMetrics/AzureFunctionsDatabricksProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/Databricks/JobMetrics/AzureFunctionsDatabricksProject.cs
@@ -73,7 +73,7 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions.Databricks.JobMetrics
 
             UpdateFileInProject("Startup.cs", contents =>
                 RemovesUserErrorsFromContents(contents)
-                    .Replace("AddAzureKeyVaultWithManagedServiceIdentity(\"https://your-keyvault.vault.azure.net/\")", 
+                    .Replace("AddAzureKeyVaultWithManagedIdentity(\"https://your-keyvault.vault.azure.net/\", CacheConfiguration.Default)", 
                              $"AddProvider(new {nameof(SingleValueSecretProvider)}(\"{securityToken}\"))"));
         }
 

--- a/src/Arcus.Templates.Tests.Integration/WebApi/WebApiProjectOptions.cs
+++ b/src/Arcus.Templates.Tests.Integration/WebApi/WebApiProjectOptions.cs
@@ -217,7 +217,7 @@ namespace Arcus.Templates.Tests.Integration.WebApi
         private static string InsertInMemorySecretStore(string contents, string secretName, string secretValue)
         {
             string newSecretProviderWithSecret = CreatesInMemorySecretProviderConstructor(secretName, secretValue);
-            return contents.Replace("AddAzureKeyVaultWithManagedServiceIdentity(\"https://your-keyvault.vault.azure.net/\")", $"AddProvider({newSecretProviderWithSecret})");
+            return contents.Replace("AddAzureKeyVaultWithManagedIdentity(\"https://your-keyvault.vault.azure.net/\", CacheConfiguration.Default)", $"AddProvider({newSecretProviderWithSecret})");
         }
 
         private static string InsertInMemorySecretProviderCode(string contents, string replacementToken, string secretName, string secretValue)

--- a/src/Arcus.Templates.Tests.Integration/Worker/ServiceBusWorkerProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/Worker/ServiceBusWorkerProject.cs
@@ -170,7 +170,7 @@ namespace Arcus.Templates.Tests.Integration.Worker
                 RemovesUserErrorsFromContents(contents)
                     .Replace("EmptyMessageHandler", nameof(OrdersMessageHandler))
                     .Replace("EmptyMessage", nameof(Order))
-                    .Replace("AddAzureKeyVaultWithManagedServiceIdentity(\"https://your-keyvault.vault.azure.net/\")", 
+                    .Replace("AddAzureKeyVaultWithManagedIdentity(\"https://your-keyvault.vault.azure.net/\", CacheConfiguration.Default)", 
                              $"AddProvider(new {nameof(SingleValueSecretProvider)}(\"{connectionString}\"))"));
         }
 

--- a/src/Arcus.Templates.WebApi/Program.cs
+++ b/src/Arcus.Templates.WebApi/Program.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using Arcus.Security.Core.Caching.Configuration;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -82,8 +83,8 @@ namespace Arcus.Templates.WebApi
                         stores.AddConfiguration(config);
 //[#endif]
 
-                        //#error Please provide a valid secret provider, for example Azure Key Vault: https://security.arcus-azure.net/features/secrets/consume-from-key-vault
-                        stores.AddAzureKeyVaultWithManagedServiceIdentity("https://your-keyvault.vault.azure.net/");
+                        //#error Please provide a valid secret provider, for example Azure Key Vault: https://security.arcus-azure.net/features/secret-store/provider/key-vault
+                        stores.AddAzureKeyVaultWithManagedIdentity("https://your-keyvault.vault.azure.net/", CacheConfiguration.Default);
                     })
                     .ConfigureWebHostDefaults(webBuilder =>
                     {


### PR DESCRIPTION
The project templates were using an 'old' and deprecated kickstart example, which is now updated to the most recent and recommended one.

Closes #318 