### PR TITLE
test: provide diagnostic error messages during integration tests

### DIFF
--- a/src/Arcus.Templates.Tests.Integration/Worker/ServiceBusWorkerProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/Worker/ServiceBusWorkerProject.cs
@@ -168,6 +168,7 @@ namespace Arcus.Templates.Tests.Integration.Worker
             string connectionString = _configuration.GetServiceBusConnectionString(_entity);
             UpdateFileInProject("Program.cs", contents => 
                 RemovesUserErrorsFromContents(contents)
+                    .Replace(".MinimumLevel.Debug()", ".MinimumLevel.Verbose()")
                     .Replace("EmptyMessageHandler", nameof(OrdersMessageHandler))
                     .Replace("EmptyMessage", nameof(Order))
                     .Replace("AddAzureKeyVaultWithManagedIdentity(\"https://your-keyvault.vault.azure.net/\", CacheConfiguration.Default)", 


### PR DESCRIPTION
Replace the Serilog debug logging with verbose logging to see more detailed error messages when the integration tests for on-the-fly generated projects based on our templates are failing.