### PR TITLE
fix: failed response request tracking

### DIFF
--- a/src/Arcus.Templates.Tests.Integration/Arcus.Templates.Tests.Integration.csproj
+++ b/src/Arcus.Templates.Tests.Integration/Arcus.Templates.Tests.Integration.csproj
@@ -36,7 +36,6 @@
     <PackageReference Include="Arcus.Messaging.Pumps.ServiceBus" Version="0.5.1" />
     <PackageReference Include="Arcus.EventGrid.Testing" Version="3.1.0" />
     <PackageReference Include="Bogus" Version="33.0.2" />
-    <PackageReference Include="BouncyCastle" Version="1.8.9" />
     <PackageReference Include="BouncyCastle.NetCoreSdk" Version="1.9.0.1" />
     <PackageReference Include="Flurl.Http" Version="3.0.1" />
     <PackageReference Include="Guard.NET" Version="1.2.0" />

--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/Databricks/JobMetrics/MetricReporting/DatabricksMetricReportingTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/Databricks/JobMetrics/MetricReporting/DatabricksMetricReportingTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Arcus.Templates.Tests.Integration.AzureFunctions.Databricks.JobMetrics.Configuration;
 using Arcus.Templates.Tests.Integration.Fixture;
 using Microsoft.Azure.ApplicationInsights.Query;
 using Microsoft.Azure.ApplicationInsights.Query.Models;
@@ -16,27 +15,24 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions.Databricks.JobMetrics
 {
     [Collection(TestCollections.Integration)]
     [Trait("Category", TestTraits.Integration)]
-    public class DatabricksMetricReportingTests
+    public class DatabricksMetricReportingTests : ApplicationInsightsTests
     {
         private readonly TestConfig _config;
-        private readonly ITestOutputHelper _outputWriter;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DatabricksMetricReportingTests"/> class.
         /// </summary>
-        public DatabricksMetricReportingTests(ITestOutputHelper outputWriter)
+        public DatabricksMetricReportingTests(ITestOutputHelper outputWriter) : base(outputWriter)
         {
-            _outputWriter = outputWriter;
             _config = TestConfig.Create();
         }
 
         [Fact]
         public async Task MinimumAzureFunctionsDatabricksProject_WithEmbeddedTimer_ReportsAsMetricPeriodically()
         {
-            ApplicationInsightsConfig applicationInsightsConfig = _config.GetApplicationInsightsConfig();
             var parameters = RunParameters.CreateNotebookParams(Enumerable.Empty<KeyValuePair<string, string>>());
 
-            using (var project = AzureFunctionsDatabricksProject.StartNew(_config, _outputWriter))
+            using (var project = AzureFunctionsDatabricksProject.StartNew(_config, Logger))
             {
                 using (var client = DatabricksClient.CreateClient(project.AzureFunctionDatabricksConfig.BaseUrl, project.AzureFunctionDatabricksConfig.SecurityToken))
                 {
@@ -47,22 +43,22 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions.Databricks.JobMetrics
             }
 
             // Assert
-            using (ApplicationInsightsDataClient client = CreateApplicationInsightsClient(applicationInsightsConfig.ApiKey))
+            await RetryAssertUntilTelemetryShouldBeAvailableAsync(async client =>
             {
-                await RetryAssertUntilTelemetryShouldBeAvailableAsync(async () =>
-                {
-                    const string past10MinFilter = "PT0.1H";
-                    var bodySchema = new MetricsPostBodySchema(
-                        id: Guid.NewGuid().ToString(),
-                     parameters: new MetricsPostBodySchemaParameters($"customMetrics/{applicationInsightsConfig.MetricName}", timespan: past10MinFilter));
+                const string past10MinFilter = "PT0.1H";
+                var bodySchema = new MetricsPostBodySchema(
+                    id: Guid.NewGuid().ToString(),
+                    parameters: new MetricsPostBodySchemaParameters(
+                        $"customMetrics/{ApplicationInsightsConfig.MetricName}",
+                        timespan: past10MinFilter));
 
-                    IList<MetricsResultsItem> results =
-                        await client.Metrics.GetMultipleAsync(applicationInsightsConfig.ApplicationId, new List<MetricsPostBodySchema> { bodySchema });
+                IList<MetricsResultsItem> results =
+                    await client.Metrics.GetMultipleAsync(ApplicationInsightsConfig.ApplicationId, new List<MetricsPostBodySchema> {bodySchema});
 
-                    Assert.NotEmpty(results);
-                    Assert.All(results, result => Assert.NotNull(result.Body.Value));
-                }, timeout: TimeSpan.FromMinutes(2));
-            }
+                Assert.NotEmpty(results);
+                Assert.All(results, result => Assert.NotNull(result.Body.Value));
+            },
+            timeout: TimeSpan.FromMinutes(2));
         }
 
         private static async Task WaitUntilDatabricksJobRunIsCompleted(DatabricksClient client, int jobId)
@@ -76,29 +72,6 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions.Databricks.JobMetrics
                         .ExecuteAsync(async () => await client.Jobs.RunsList(jobId, activeOnly: true));
 
             await Task.Delay(TimeSpan.FromMinutes(2));
-        }
-
-        private static ApplicationInsightsDataClient CreateApplicationInsightsClient(string apiKey)
-        {
-            var clientCredentials = new ApiKeyClientCredentials(apiKey);
-            var client = new ApplicationInsightsDataClient(clientCredentials);
-
-            return client;
-        }
-
-        private async Task RetryAssertUntilTelemetryShouldBeAvailableAsync(Func<Task> assertion, TimeSpan timeout)
-        {
-            AsyncRetryPolicy retryPolicy =
-                Policy.Handle<Exception>(exception =>
-                      {
-                          _outputWriter.WriteLine("Failed to contact Azure Application Insights. Reason: {0}", exception.Message);
-                          return true;
-                      })
-                      .WaitAndRetryForeverAsync(index => TimeSpan.FromSeconds(1));
-
-            await Policy.TimeoutAsync(timeout)
-                        .WrapAsync(retryPolicy)
-                        .ExecuteAsync(assertion);
         }
     }
 }

--- a/src/Arcus.Templates.Tests.Integration/Fixture/ApplicationInsightsTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/Fixture/ApplicationInsightsTests.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Arcus.Templates.Tests.Integration.AzureFunctions.Databricks.JobMetrics.Configuration;
+using GuardNet;
+using Microsoft.Azure.ApplicationInsights.Query;
+using Polly;
+using Polly.Retry;
+using Xunit.Abstractions;
+
+namespace Arcus.Templates.Tests.Integration.Fixture
+{
+    /// <summary>
+    /// Represents an integration test class that uses Azure Application Insights to assert the test result.
+    /// </summary>
+    public abstract class ApplicationInsightsTests
+    {
+        /// <summary>
+        /// Gets the filter statement that limits the query result to only telemetry from the last hour.
+        /// </summary>
+        protected const string OnlyLastHourFilter = "timestamp gt now() sub duration'PT1H'";
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApplicationInsightsTests" /> class.
+        /// </summary>
+        /// <param name="outputWriter">The logger instance to write diagnostic trace messages during the interaction with Azure Application Insights.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="outputWriter"/> is <c>null</c>.</exception>
+        protected ApplicationInsightsTests(ITestOutputHelper outputWriter) : this(TestConfig.Create(), outputWriter)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApplicationInsightsTests" /> class.
+        /// </summary>
+        /// <param name="configuration">The test configuration used during the tests.</param>
+        /// <param name="outputWriter">The logger instance to write diagnostic trace messages during the interaction with Azure Application Insights.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="configuration"/> or the <paramref name="outputWriter"/> is <c>null</c>.</exception>
+        protected ApplicationInsightsTests(TestConfig configuration, ITestOutputHelper outputWriter)
+        {
+            Guard.NotNull(outputWriter, nameof(outputWriter), "Requires a logger instance to write diagnostic trace messages during the interaction with Azure Application Insights");
+
+            Configuration = configuration;
+            ApplicationInsightsConfig = Configuration.GetApplicationInsightsConfig();
+            Logger = outputWriter;
+        }
+
+        /// <summary>
+        /// Gets the configuration used during the tests.
+        /// </summary>
+        protected TestConfig Configuration { get; }
+
+        /// <summary>
+        /// Gets the sub-set of the test <see cref="Configuration"/> that includes all the Azure Application Insights information.
+        /// </summary>
+        protected ApplicationInsightsConfig ApplicationInsightsConfig { get; }
+        
+        /// <summary>
+        /// Gets the instance to write diagnostic messages.
+        /// </summary>
+        protected ITestOutputHelper Logger { get; }
+
+        /// <summary>
+        /// Reliable assertion that retries an <paramref name="assertion"/> until the assert result succeeds or the <paramref name="timeout"/> expires.
+        /// </summary>
+        /// <param name="assertion">The test assertion to verify custom results.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="assertion"/> is <c>null</c>.</exception>
+        public async Task RetryAssertUntilTelemetryShouldBeAvailableAsync(Func<ApplicationInsightsDataClient, Task> assertion)
+        {
+            await RetryAssertUntilTelemetryShouldBeAvailableAsync(assertion, timeout: TimeSpan.FromMinutes(7));
+        }
+        
+        /// <summary>
+        /// Reliable assertion that retries an <paramref name="assertion"/> until the assert result succeeds or the <paramref name="timeout"/> expires.
+        /// </summary>
+        /// <param name="assertion">The test assertion to verify custom results.</param>
+        /// <param name="timeout">The maximum time range the <paramref name="assertion"/> is allowed to be retried.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="assertion"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="timeout"/> is a negative time span.</exception>
+        protected async Task RetryAssertUntilTelemetryShouldBeAvailableAsync(Func<ApplicationInsightsDataClient, Task> assertion, TimeSpan timeout)
+        {
+            Guard.NotNull(assertion, nameof(assertion), "Requires a test assertion to verify custom results");
+            Guard.NotLessThan(timeout, TimeSpan.Zero, nameof(timeout), "Requires a positive time span for the timeout");
+
+            using (ApplicationInsightsDataClient client = CreateApplicationInsightsClient())
+            {
+                AsyncRetryPolicy retryPolicy =
+                    Policy.Handle<Exception>(exception =>
+                          {
+                              Logger.WriteLine("Failed to contact Azure Application Insights. Reason: {0}", exception);
+                              return true;
+                          })
+                          .WaitAndRetryForeverAsync(index => TimeSpan.FromSeconds(3));
+
+                await Policy.TimeoutAsync(timeout)
+                            .WrapAsync(retryPolicy)
+                            .ExecuteAsync(() => assertion(client));
+            }
+        }
+
+        private ApplicationInsightsDataClient CreateApplicationInsightsClient()
+        {
+            var clientCredentials = new ApiKeyClientCredentials(ApplicationInsightsConfig.ApiKey);
+            var client = new ApplicationInsightsDataClient(clientCredentials);
+
+            return client;
+        }
+    }
+}

--- a/src/Arcus.Templates.Tests.Integration/WebApi/Logging/v1/RequestTrackingTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/WebApi/Logging/v1/RequestTrackingTests.cs
@@ -1,0 +1,54 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Arcus.Templates.Tests.Integration.Fixture;
+using Microsoft.Azure.ApplicationInsights.Query;
+using Microsoft.Azure.ApplicationInsights.Query.Models;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Arcus.Templates.Tests.Integration.WebApi.Logging.v1
+{
+    [Collection(TestCollections.Integration)]
+    [Trait("Category", TestTraits.Integration)]
+    public class RequestTrackingTests : ApplicationInsightsTests
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RequestTrackingTests" /> class.
+        /// </summary>
+        public RequestTrackingTests(ITestOutputHelper outputWriter) : base(outputWriter)
+        {
+        }
+
+        [Fact]
+        public async Task GetSabotagedEndpoint_TracksFailedResponse_ReturnsFailedResponse()
+        {
+            // Arrange
+            var optionsWithSerilogLogging =
+                new WebApiProjectOptions().WithSerilogLogging(ApplicationInsightsConfig.InstrumentationKey);
+            
+            using (var project = WebApiProject.CreateNew(Configuration, optionsWithSerilogLogging, Logger))
+            {
+                project.AddTypeAsFile<SaboteurController>();
+                await project.StartAsync();
+
+                // Act
+                using (HttpResponseMessage response = await project.Root.GetAsync(SaboteurController.Route))
+                {
+                    // Assert
+                    Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+                    await RetryAssertUntilTelemetryShouldBeAvailableAsync(async client =>
+                    {
+                        EventsResults<EventsRequestResult> results =
+                            await client.Events.GetRequestEventsAsync(ApplicationInsightsConfig.ApplicationId, filter: OnlyLastHourFilter);
+
+                        Assert.Contains(results.Value, result =>
+                        {
+                            return result.Request.Url.Contains("sabotage") && result.Request.ResultCode == "500";
+                        });
+                    });
+                }
+            }
+        }
+    }
+}

--- a/src/Arcus.Templates.Tests.Integration/WebApi/Logging/v1/SaboteurController.cs
+++ b/src/Arcus.Templates.Tests.Integration/WebApi/Logging/v1/SaboteurController.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Arcus.Templates.Tests.Integration.WebApi.Logging.v1
+{
+    /// <summary>
+    /// Represents an API controller that sabotage the HTTP endpoint by throwing an exception.
+    /// </summary>
+    [Route("api/v1")]
+    [ApiController]
+    public class SaboteurController : ControllerBase
+    {
+        public const string Route = "sabotage";
+        
+        [HttpGet]
+        [Route(Route)]
+        public IActionResult Sabotage()
+        {
+            throw new Exception("Sabotage the HTTP endpoint by throwing an general exception");
+        }
+    }
+}

--- a/src/Arcus.Templates.WebApi/Startup.cs
+++ b/src/Arcus.Templates.WebApi/Startup.cs
@@ -267,12 +267,12 @@ namespace Arcus.Templates.WebApi
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
-            app.UseExceptionHandling();
 #if (ExcludeCorrelation == false)
             app.UseHttpCorrelation();
 #endif
             app.UseRouting();
             app.UseRequestTracking();
+            app.UseExceptionHandling();
 
 #warning Please configure application with HTTPS transport layer security and set 'useSSL' in the Docker 'launchSettings.json' back to 'true'
 


### PR DESCRIPTION
Moved the exception handling after the request tracking and add a test that proves this.
The exception handling will therefore not handling exceptions from the routing and tracking and correlation but only for the processes that comes after.

Relates to https://github.com/arcus-azure/arcus.webapi/discussions/208