### PR TITLE
fix: support parsing of JSON arrays

### DIFF
--- a/src/Arcus.Templates.AzureFunctions.Http/HttpBasedAzureFunction.cs
+++ b/src/Arcus.Templates.AzureFunctions.Http/HttpBasedAzureFunction.cs
@@ -100,7 +100,7 @@ namespace Arcus.Templates.AzureFunctions.Http
             using (var streamReader = new StreamReader(request.Body))
             using (var jsonReader = new JsonTextReader(streamReader))
             {
-                JObject parsedOrder = await JObject.LoadAsync(jsonReader);
+                JToken parsedOrder = await JToken.LoadAsync(jsonReader);
                 var model = parsedOrder.ToObject<TMessage>(JsonSerializer);
                 Validator.ValidateObject(model, new ValidationContext(model), validateAllProperties: true);
                 

--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/Http/Api/OrderService.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/Http/Api/OrderService.cs
@@ -43,7 +43,25 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions.Http.Api
         /// <exception cref="ArgumentNullException">Thrown when the <paramref name="order"/> is <c>null</c>.</exception>
         public async Task<HttpResponseMessage> PostAsync(Order order)
         {
+            Guard.NotNull(order, nameof(order), $"Requires an '{nameof(Order)}' model to post to the Azure Functions HTTP trigger");
+
             string json = JsonConvert.SerializeObject(order);
+            HttpResponseMessage response = await PostAsync(json);
+
+            return response;
+        }
+        
+        /// <summary>
+        /// HTTP POST an <paramref name="json"/> to the 'Order' HTTP trigger of the Azure Functions test project.
+        /// </summary>
+        /// <param name="json">The order to send to the HTTP trigger.</param>
+        /// <returns>
+        ///     The HTTP response of the HTTP trigger.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="json"/> is <c>null</c>.</exception>
+        public async Task<HttpResponseMessage> PostAsync(string json)
+        {
+            Guard.NotNull(json, nameof(json), $"Requires a JSON content representation of an '{nameof(Order)}' model to post to the Azure Function HTTP trigger");
             var content = new StringContent(json);
             
             using (var request = new HttpRequestMessage(HttpMethod.Post, _orderEndpoint))

--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/Http/AzureFunctionsHttpProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/Http/AzureFunctionsHttpProject.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Arcus.Templates.Tests.Integration.AzureFunctions.Http.Api;
 using Arcus.Templates.Tests.Integration.Fixture;
 using Flurl;
+using GuardNet;
 using Xunit.Abstractions;
 
 namespace Arcus.Templates.Tests.Integration.AzureFunctions.Http
@@ -44,21 +45,37 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions.Http
         /// Starts a newly created project from the Azure Functions HTTP project template.
         /// </summary>
         /// <param name="configuration">The configuration to control the hosting of the to-be-created project.</param>
-        /// <param name="outputWriter">The output logger to add telemetry information during the creation and startup process.</param>
+        /// <param name="outputWriter">The output logger to write telemetry information during the creation and startup process.</param>
         /// <returns>
-        ///     A Azure Functions HTTP project with a full set of endpoint services to interact with the Azure Function.
+        ///     An Azure Functions HTTP project with a full set of endpoint services to interact with.
         /// </returns>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="configuration"/> or <paramref name="outputWriter"/> is <c>null</c>.</exception>
         /// <exception cref="CannotStartTemplateProjectException">Thrown when the Azure Functions project cannot be started correctly.</exception>
         public static async Task<AzureFunctionsHttpProject> StartNewAsync(TestConfig configuration, ITestOutputHelper outputWriter)
         {
+            Guard.NotNull(configuration, nameof(configuration), "Requires a configuration instance to control the hosting of the to-be-created project");
+            Guard.NotNull(outputWriter, nameof(outputWriter), "Requires a test logger to write diagnostic information during the creation and startup process");
+
             AzureFunctionsHttpProject project = CreateNew(configuration, outputWriter);
             await project.StartAsync();
 
             return project;
         }
 
-        private static AzureFunctionsHttpProject CreateNew(TestConfig configuration, ITestOutputHelper outputWriter)
+        /// <summary>
+        /// Creates a new temporary project based on the Azure Functions HTTP trigger project template.
+        /// </summary>
+        /// <param name="configuration">The configuration to control the hosting of the to-be-created project.</param>
+        /// <param name="outputWriter">The output logger to write telemetry information during the creation and startup process.</param>
+        /// <returns>
+        ///     An Azure Functions HTTP trigger project with a full set of endpoint services to interact with.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="configuration"/> or <paramref name="outputWriter"/> is <c>null</c>.</exception>
+        public static AzureFunctionsHttpProject CreateNew(TestConfig configuration, ITestOutputHelper outputWriter)
         {
+            Guard.NotNull(configuration, nameof(configuration), "Requires a configuration instance to control the hosting of the to-be-created project");
+            Guard.NotNull(outputWriter, nameof(outputWriter), "Requires a test logger to write diagnostic information during the creation and startup process");
+            
             var project = new AzureFunctionsHttpProject(configuration, outputWriter);
             project.CreateNewProject(new ProjectOptions());
             project.AddStorageAccount();
@@ -66,9 +83,12 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions.Http
             return project;
         }
 
-        private async Task StartAsync()
+        /// <summary>
+        /// Starts the Azure Functions HTTP trigger project, created from the template.
+        /// </summary>
+        public async Task StartAsync()
         {
-            Run(BuildConfiguration.Debug, TargetFramework.NetCoreApp31);
+            Run(BuildConfiguration.Release, TargetFramework.NetCoreApp31);
             await WaitUntilTriggerIsAvailableAsync(OrderFunctionEndpoint);
         }
     }

--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/Http/Fix/OrderBatchTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/Http/Fix/OrderBatchTests.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Arcus.Templates.AzureFunctions.Http;
+using Arcus.Templates.AzureFunctions.Http.Model;
+using Arcus.Templates.Tests.Integration.Fixture;
+using Bogus;
+using Newtonsoft.Json;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Arcus.Templates.Tests.Integration.AzureFunctions.Http.Fix
+{
+    [Collection(TestCollections.Integration)]
+    [Trait("Category", TestTraits.Integration)]
+    public class OrderBatchTests
+    {
+        private readonly ITestOutputHelper _outputWriter;
+
+        private static readonly Faker BogusGenerator = new Faker();
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OrderBatchTests" /> class.
+        /// </summary>
+        public OrderBatchTests(ITestOutputHelper outputWriter)
+        {
+            _outputWriter = outputWriter;
+        }
+        
+        [Fact]
+        public async Task OrderFunction_ReceivedBatchedOrders_ReturnsSuccess()
+        {
+            // Arrange
+            var config = TestConfig.Create();
+            using (var project = AzureFunctionsHttpProject.CreateNew(config, _outputWriter))
+            {
+                project.UpdateFileInProject($"{nameof(OrderFunction)}.cs", contents =>
+                {
+                    return contents.Replace("GetJsonBodyAsync<Order>", "GetJsonBodyAsync<Order[]>");
+                });
+                await project.StartAsync();
+
+                IEnumerable<Order> orders = BogusGenerator.Make(3, CreateRandomOrder);
+                string json = JsonConvert.SerializeObject(orders.ToArray());
+
+                // Act
+                using (HttpResponseMessage response = await project.Order.PostAsync(json))
+                {
+                    // Assert
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                }
+            }
+        }
+
+        private static Order CreateRandomOrder()
+        {
+            var order = new Order
+            {
+                Id = Guid.NewGuid().ToString(),
+                ArticleNumber = BogusGenerator.Random.String(1, 100),
+                Scheduled = BogusGenerator.Date.RecentOffset()
+            };
+
+            return order;
+        }
+    }
+}


### PR DESCRIPTION
Use `JToken` to parse incoming HTTP request bodies so we can support JSON arrays.

Closes #330 