### PR TITLE
chore(deps): update with necessary host packages

### DIFF
--- a/src/Arcus.Templates.ServiceBus.Queue/Arcus.Templates.ServiceBus.Queue.csproj
+++ b/src/Arcus.Templates.ServiceBus.Queue/Arcus.Templates.ServiceBus.Queue.csproj
@@ -52,6 +52,7 @@
     <PackageReference Include="Arcus.Security.Core" Version="1.5.0" />
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.5.0" />
     <PackageReference Include="Guard.NET" Version="1.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.14" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Serilog" Version="2.10.0" Condition="'$(ExcludeSerilog)' == 'false'" />

--- a/src/Arcus.Templates.ServiceBus.Topic/Arcus.Templates.ServiceBus.Topic.csproj
+++ b/src/Arcus.Templates.ServiceBus.Topic/Arcus.Templates.ServiceBus.Topic.csproj
@@ -52,6 +52,7 @@
     <PackageReference Include="Arcus.Security.Core" Version="1.5.0" />
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.5.0" />
     <PackageReference Include="Guard.NET" Version="1.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.14" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Serilog" Version="2.10.0" Condition="'$(ExcludeSerilog)' == 'false'" />


### PR DESCRIPTION
With the update of our new Arcus.Messaging package, we have limited the amount of dependencies and so, don't implicitly reference the hosting package anymore. Which is the reason why this update was failing.