### PR TITLE
test: increase Azure Databricks timeout

### DIFF
--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/Databricks/JobMetrics/MetricReporting/DatabricksMetricReportingTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/Databricks/JobMetrics/MetricReporting/DatabricksMetricReportingTests.cs
@@ -67,7 +67,7 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions.Databricks.JobMetrics
                 Policy.HandleResult<RunList>(list => list.Runs is null || list.Runs.Any(r => !r.IsCompleted))
                       .WaitAndRetryForeverAsync(index => TimeSpan.FromSeconds(10));
 
-            await Policy.TimeoutAsync(TimeSpan.FromMinutes(7))
+            await Policy.TimeoutAsync(TimeSpan.FromMinutes(10))
                         .WrapAsync(retryPolicy)
                         .ExecuteAsync(async () => await client.Jobs.RunsList(jobId, activeOnly: true));
 


### PR DESCRIPTION
Don't ask me why, but apparently, the Databricks job takes longer now then before to complete. Maybe because the resource being used by other parties more? Don't know, actually. Let's hope it's more stable mow. 