### PR TITLE
fix: set Microsoft log level to warning

### DIFF
--- a/src/Arcus.Templates.WebApi/.template.config/template.json
+++ b/src/Arcus.Templates.WebApi/.template.config/template.json
@@ -52,6 +52,14 @@
       },
       "replaces": "//[#if DEBUG]"
     },
+    "ElseDirective": {
+      "type": "generated",
+      "generator": "constant",
+      "parameters": {
+        "value": "#else"
+      },
+      "replaces": "//[#else]"
+    },
     "EndIf": {
       "type": "generated",
       "generator": "constant",

--- a/src/Arcus.Templates.WebApi/Startup.cs
+++ b/src/Arcus.Templates.WebApi/Startup.cs
@@ -311,7 +311,7 @@ namespace Arcus.Templates.WebApi
             
             return new LoggerConfiguration()
                 .MinimumLevel.Debug()
-                .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
+                .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
                 .Enrich.FromLogContext()
                 .Enrich.WithVersion()
                 .Enrich.WithComponentName("API")

--- a/src/Arcus.Templates.WebApi/Startup.cs
+++ b/src/Arcus.Templates.WebApi/Startup.cs
@@ -310,7 +310,11 @@ namespace Arcus.Templates.WebApi
             var instrumentationKey = Configuration.GetValue<string>(ApplicationInsightsInstrumentationKeyName);
             
             return new LoggerConfiguration()
+//[#if DEBUG]
                 .MinimumLevel.Debug()
+//[#else]
+                .MinimumLevel.Information()
+//[#endif]
                 .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
                 .Enrich.FromLogContext()
                 .Enrich.WithVersion()


### PR DESCRIPTION
To reduce logs from Microsoft, we should set it to warning.

Closes #354 