### PR TITLE
chore: streamline order events on az service bus

### DIFF
--- a/src/Arcus.Templates.Tests.Integration/Worker/Fixture/Customer.cs
+++ b/src/Arcus.Templates.Tests.Integration/Worker/Fixture/Customer.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+
+namespace Arcus.Templates.Tests.Integration.Worker.Fixture
+{
+    public class Customer
+    {
+        [JsonProperty]
+        public string FirstName { get; private set; }
+
+        [JsonProperty]
+        public string LastName { get; private set; }
+    }
+}

--- a/src/Arcus.Templates.Tests.Integration/Worker/Fixture/Order.cs
+++ b/src/Arcus.Templates.Tests.Integration/Worker/Fixture/Order.cs
@@ -12,5 +12,8 @@ namespace Arcus.Templates.Tests.Integration.Worker.Fixture
 
         [JsonProperty]
         public string ArticleNumber { get; set; }
+
+        [JsonProperty]
+        public Customer Customer { get; set; }
     }
 }

--- a/src/Arcus.Templates.Tests.Integration/Worker/Fixture/OrderCreatedEvent.cs
+++ b/src/Arcus.Templates.Tests.Integration/Worker/Fixture/OrderCreatedEvent.cs
@@ -9,11 +9,10 @@ namespace Arcus.Templates.Tests.Integration.Worker.Fixture
         private const string DefaultDataVersion = "1";
         private const string DefaultEventType = "Arcus.Samples.Orders.OrderCreated";
 
-        public OrderCreatedEvent(string eventId, string orderId, int amount, string articleNumber, MessageCorrelationInfo correlationInfo)
-            : base(eventId, subject: "order-created",
-                   new OrderCreatedEventData(orderId, amount, articleNumber, correlationInfo),
-                   DefaultDataVersion,
-                   DefaultEventType)
+        public OrderCreatedEvent(string eventId, string orderId, int amount, string articleNumber, string customerName, MessageCorrelationInfo correlationInfo)
+            : base(eventId, $"customer/{customerName}",
+                new OrderCreatedEventData(orderId, amount, articleNumber, customerName, correlationInfo), DefaultDataVersion,
+                DefaultEventType)
         {
         }
 

--- a/src/Arcus.Templates.Tests.Integration/Worker/Fixture/OrderCreatedEventData.cs
+++ b/src/Arcus.Templates.Tests.Integration/Worker/Fixture/OrderCreatedEventData.cs
@@ -4,17 +4,19 @@ namespace Arcus.Templates.Tests.Integration.Worker.Fixture
 {
     public class OrderCreatedEventData
     {
-        public OrderCreatedEventData(string id, int amount, string articleNumber, MessageCorrelationInfo correlationInfo)
+        public OrderCreatedEventData(string id, int amount, string articleNumber, string customerName, MessageCorrelationInfo correlationInfo)
         {
             Id = id;
             Amount = amount;
             ArticleNumber = articleNumber;
+            CustomerName = customerName;
             CorrelationInfo = correlationInfo;
         }
 
         public string Id { get; set; }
         public int Amount { get; set; }
         public string ArticleNumber { get; set; }
+        public string CustomerName { get; set; }
         public MessageCorrelationInfo CorrelationInfo { get; set; }
     }
 }

--- a/src/Arcus.Templates.Tests.Integration/Worker/Fixture/OrdersMessageHandler.cs
+++ b/src/Arcus.Templates.Tests.Integration/Worker/Fixture/OrdersMessageHandler.cs
@@ -64,7 +64,9 @@ namespace Arcus.Templates.Tests.Integration.Worker.Fixture
                 orderMessage.Id,
                 orderMessage.Amount,
                 orderMessage.ArticleNumber,
+                $"{orderMessage.Customer.FirstName} {orderMessage.Customer.LastName}",
                 correlationInfo);
+
             var orderCreatedEvent = new CloudEvent(
                 CloudEventsSpecVersion.V1_0,
                 "OrderCreatedEvent",

--- a/src/Arcus.Templates.Tests.Integration/Worker/MessagePump/MessagePumpService.cs
+++ b/src/Arcus.Templates.Tests.Integration/Worker/MessagePump/MessagePumpService.cs
@@ -111,7 +111,12 @@ namespace Arcus.Templates.Tests.Integration.Worker.MessagePump
 
         private static Order GenerateOrder()
         {
+             var customerGenerator = new Faker<Customer>()
+                .RuleFor(u => u.FirstName, (f, u) => f.Name.FirstName())
+                .RuleFor(u => u.LastName, (f, u) => f.Name.LastName());
+
             var orderGenerator = new Faker<Order>()
+                .RuleFor(u => u.Customer, () => customerGenerator)
                 .RuleFor(u => u.Id, f => Guid.NewGuid().ToString())
                 .RuleFor(u => u.Amount, f => f.Random.Int())
                 .RuleFor(u => u.ArticleNumber, f => f.Commerce.Product());

--- a/src/Arcus.Templates.Tests.Integration/Worker/ServiceBusWorkerProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/Worker/ServiceBusWorkerProject.cs
@@ -160,6 +160,7 @@ namespace Arcus.Templates.Tests.Integration.Worker
             AddPackage("Arcus.EventGrid", "3.1.0");
             AddPackage("Arcus.EventGrid.Publishing", "3.1.0");
             AddTypeAsFile<Order>();
+            AddTypeAsFile<Customer>();
             AddTypeAsFile<OrderCreatedEvent>();
             AddTypeAsFile<OrderCreatedEventData>();
             AddTypeAsFile<OrdersMessageHandler>();


### PR DESCRIPTION
Streamlining the type of messages with the messaging repo that are set on the queue will remove the problem when leftover messages result in 'unhandled messages' in the logs.
Makes it cleaner and more understabable.