### PR TITLE
fix: use ubuntu-latest for build pipelines

### DIFF
--- a/build/ci-build.yml
+++ b/build/ci-build.yml
@@ -41,7 +41,7 @@ stages:
     jobs:
       - job: Compile
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: '$(Vm.Image)'
         steps:
           - template: nuget/determine-pr-version.yml@templates
             parameters:
@@ -85,7 +85,7 @@ stages:
       - job: RunIntegrationTests
         displayName: 'Run integration tests'
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: '$(Vm.Image)'
         steps:
           - template: 'templates/install-azure-functions-core-tools.yml'
           - template: test/run-integration-tests.yml@templates
@@ -104,7 +104,7 @@ stages:
       - job: PushToMyGet
         displayName: 'Push to MyGet'
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: '$(Vm.Image)'
         steps:
           - task: DownloadPipelineArtifact@2
             displayName: 'Download build artifacts'

--- a/build/nuget-release.yml
+++ b/build/nuget-release.yml
@@ -31,7 +31,7 @@ stages:
     jobs:
       - job: Compile
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: '$(Vm.Image)'
         steps:
           - task: qetza.replacetokens.replacetokens-task.replacetokens@3
             displayName: 'Replace .template.json version'
@@ -71,7 +71,7 @@ stages:
       - job: RunIntegrationTests
         displayName: 'Run integration tests'
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: '$(Vm.Image)'
         steps:
           - template: 'templates/install-azure-functions-core-tools.yml'
           - template: test/run-integration-tests.yml@templates
@@ -88,7 +88,7 @@ stages:
       - job: PushToNuGet
         displayName: 'Push to NuGet.org'
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: '$(Vm.Image)'
         steps:
           - task: DownloadPipelineArtifact@2
             displayName: 'Download build artifacts'

--- a/build/variables/build.yml
+++ b/build/variables/build.yml
@@ -1,3 +1,4 @@
 variables:
   DotNet.Sdk.Version: '3.1.200'
   Project: 'Arcus.Templates'
+  Vm.Image: 'ubuntu-latest'


### PR DESCRIPTION
Use `ubuntu-latest` for the VM image of the build pipelines.

Relates to https://github.com/arcus-azure/arcus/issues/144