### PR TITLE
fix: Resolve a NU1608 warning in the Arcus.Templates.Tests.Integration.csproj

### DIFF
--- a/src/Arcus.Templates.Tests.Integration/Arcus.Templates.Tests.Integration.csproj
+++ b/src/Arcus.Templates.Tests.Integration/Arcus.Templates.Tests.Integration.csproj
@@ -52,6 +52,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+  <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hi, I found a NU1608 warning in the Arcus.Templates.Tests.Integration.csproj:

`Warning NU1608 Detected package version outside of dependency constraint: Microsoft.Azure.ServiceBus 4.1.1 requires System.IdentityModel.Tokens.Jwt (>= 5.4.0 && < 6.0.0) but version System.IdentityModel.Tokens.Jwt 6.11.1 was resolved.`

This fix can remove the warning from Arcus.Templates's dependency graph.
Hope the PR can help you.

Best regards,
sucrose