### PR TITLE
feat: opt-in health checks for az func http trigger proj template

### DIFF
--- a/docs/preview/azurefunctions-http-template.md
+++ b/docs/preview/azurefunctions-http-template.md
@@ -23,12 +23,19 @@ When installed, the template can be created with shortname: `arcus-az-func-http`
 
 Creates a starter worker project with by default configured:
 
-* Azure Function HTTP trigger with:
+* Arcus secret store setup with Azure Key Vault secret provider (see more info [here](https://security.arcus-azure.net/features/secret-store/) on what this includes)
+* [Serilog](https://serilog.net/) as logging mechanism with default enrichers ([version](https://observability.arcus-azure.net/features/telemetry-enrichment#version-enricher), [application](https://observability.arcus-azure.net/features/telemetry-enrichment#application-enricher), and [correlation](https://webapi.arcus-azure.net/features/telemetry) when appropriate), sinking to Application Insights.
+
+* Example Azure Function HTTP 'order' trigger with:
     * HTTP correlation (see more info [here](https://webapi.arcus-azure.net/features/correlation) on what this includes)
     * Request content and header to restrict to JSON content and JSON parsing with data model annotations validation
-    * Arcus secret store setup with Azure Key Vault secret provider (see more info [here](https://security.arcus-azure.net/features/secret-store/) on what this includes)
-    * [Serilog](https://serilog.net/) as logging mechanism with default enrichers ([version](https://observability.arcus-azure.net/features/telemetry-enrichment#version-enricher), [application](https://observability.arcus-azure.net/features/telemetry-enrichment#application-enricher), and [correlation](https://webapi.arcus-azure.net/features/telemetry) when appropriate), sinking to Application Insights.
     * General exception handling that results in 500 Internal Server Error
+
+### Configuration
+
+And additional features available with options:
+
+* `--include-healthchecks` (default `false`): include a default Health Azure Function and health check services from the project
 
 ### Security
 

--- a/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/.template.config/template.json
+++ b/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/.template.config/template.json
@@ -69,7 +69,7 @@
       "args": {
         "referenceType": "package",
         "reference": "Microsoft.NET.Sdk.Functions",
-        "version": "3.0.9",
+        "version": "3.0.13",
         "projectFileExtensions": ".csproj"
       }
     }

--- a/src/Arcus.Templates.AzureFunctions.Http/.template.config/ide.host.json
+++ b/src/Arcus.Templates.AzureFunctions.Http/.template.config/ide.host.json
@@ -10,6 +10,12 @@
   "icon": "icon.jpg",
   "isApi": true,
   "symbolInfo": [
-
+    {
+      "id": "include-healthchecks",
+      "name": {
+        "text": "Include Health Checks"
+      },
+      "isVisible": true 
+    }
   ]
 }

--- a/src/Arcus.Templates.AzureFunctions.Http/.template.config/template.json
+++ b/src/Arcus.Templates.AzureFunctions.Http/.template.config/template.json
@@ -27,6 +27,14 @@
         "**/*.filelist",
         "**/*.user",
         "**/*.lock.json"
+      ],
+      "modifiers": [
+        {
+          "condition": "IncludeHealthChecks",
+          "include": [
+            "HealthFunction.cs"
+          ]
+        }
       ]
     }
   ],
@@ -53,7 +61,17 @@
         "value": "#endif"
       },
       "replaces": "//[#endif]"
-    }
+    },
+    "include-healthchecks": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Include a health checks Azure Function to verify if the running Azure Function is healthy"
+    },
+    "IncludeHealthChecks": {
+      "type": "computed",
+      "value": "include-healthchecks"
+    } 
   },
   "postActions": [
     {
@@ -68,7 +86,7 @@
       "args": {
         "referenceType": "package",
         "reference": "Microsoft.NET.Sdk.Functions",
-        "version": "3.0.9",
+        "version": "3.0.13",
         "projectFileExtensions": ".csproj"
       }
     }

--- a/src/Arcus.Templates.AzureFunctions.Http/.template.config/template.json
+++ b/src/Arcus.Templates.AzureFunctions.Http/.template.config/template.json
@@ -30,8 +30,8 @@
       ],
       "modifiers": [
         {
-          "condition": "IncludeHealthChecks",
-          "include": [
+          "condition": "!(IncludeHealthChecks)",
+          "exclude": [
             "HealthFunction.cs"
           ]
         }

--- a/src/Arcus.Templates.AzureFunctions.Http/HealthFunction.cs
+++ b/src/Arcus.Templates.AzureFunctions.Http/HealthFunction.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Arcus.WebApi.Logging.Correlation;
+using GuardNet;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+
+namespace Arcus.Templates.AzureFunctions.Http
+{
+    /// <summary>
+    /// Represents the health check Azure Function to verify if the running Azure Function is healthy.
+    /// </summary>
+    public class HealthFunction : HttpBasedAzureFunction
+    {
+        private readonly HealthCheckService _healthCheckService;
+        
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HealthFunction" /> class.
+        /// </summary>
+        /// <param name="healthCheckService">The service to check the current health of the running Azure Function.</param>
+        /// <param name="httpCorrelation">The instance to handle the HTTP request correlation.</param>
+        /// <param name="logger">The logger instance to write diagnostic trace messages while handling the HTTP request.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="httpCorrelation"/> is <c>null</c>.</exception>
+        public HealthFunction(
+            HealthCheckService healthCheckService, 
+            HttpCorrelation httpCorrelation, 
+            ILogger<HealthFunction> logger) 
+            : base(httpCorrelation, logger)
+        {
+            Guard.NotNull(healthCheckService, nameof(healthCheckService), "Requires a health check service to check the current health of the running Azure Function");
+            _healthCheckService = healthCheckService;
+        }
+
+        [FunctionName("health")]
+        public async Task<IActionResult> Run(
+            [HttpTrigger(AuthorizationLevel.Function, "get", Route = "v1/health")] HttpRequest request,
+            CancellationToken cancellation)
+        {
+            try
+            {
+                Logger.LogInformation("C# HTTP trigger 'health' function processed a request");
+                if (AcceptsJson(request) == false)
+                {
+                    string accept = String.Join(", ", GetAcceptMediaTypes(request));
+                    Logger.LogError("Could not process current request because the response could not accept JSON (Accept: {Accept})", accept);
+                    
+                    return UnsupportedMediaType("Could not process current request because the response could not accept JSON");
+                }
+
+                if (TryHttpCorrelate(out string errorMessage) == false)
+                {
+                    return BadRequest(errorMessage);
+                }
+
+                HealthReport healthReport = await _healthCheckService.CheckHealthAsync(cancellation);
+                if (healthReport?.Status == HealthStatus.Healthy)
+                {
+                    return Json(healthReport);
+                }
+
+                return new ObjectResult(healthReport)
+                {
+                    StatusCode = StatusCodes.Status503ServiceUnavailable
+                };
+            }
+            catch (Exception exception)
+            {
+                Logger.LogCritical(exception, exception.Message);
+                return InternalServerError("Could not process the current request due to an unexpected exception");
+            }
+        } 
+    }
+}

--- a/src/Arcus.Templates.AzureFunctions.Http/HttpBasedAzureFunction.cs
+++ b/src/Arcus.Templates.AzureFunctions.Http/HttpBasedAzureFunction.cs
@@ -51,7 +51,8 @@ namespace Arcus.Templates.AzureFunctions.Http
 
             var jsonOptions = new JsonSerializerOptions
             {
-                IgnoreNullValues = true
+                IgnoreNullValues = true,
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
             };
             jsonOptions.Converters.Add(new JsonStringEnumConverter());
             OutputFormatters = new FormatterCollection<IOutputFormatter> {new SystemTextJsonOutputFormatter(jsonOptions)};

--- a/src/Arcus.Templates.AzureFunctions.Http/OrderFunction.cs
+++ b/src/Arcus.Templates.AzureFunctions.Http/OrderFunction.cs
@@ -40,7 +40,7 @@ namespace Arcus.Templates.AzureFunctions.Http
         {
             try
             {
-                Logger.LogInformation("C# HTTP trigger function processed a request.");
+                Logger.LogInformation("C# HTTP trigger 'order' function processed a request");
                 if (IsJson(request) == false || AcceptsJson(request) == false)
                 {
                     string accept = String.Join(", ", GetAcceptMediaTypes(request));

--- a/src/Arcus.Templates.AzureFunctions.Http/Startup.cs
+++ b/src/Arcus.Templates.AzureFunctions.Http/Startup.cs
@@ -28,6 +28,10 @@ namespace Arcus.Templates.AzureFunctions.Http
             IConfiguration config = builder.GetContext().Configuration;
 
             builder.AddHttpCorrelation();
+#if IncludeHealthChecks
+            builder.Services.AddHealthChecks();
+#endif
+
             builder.ConfigureSecretStore(stores =>
             {
 //[#if DEBUG]

--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/Http/AzureFunctionsHttpProjectOptions.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/Http/AzureFunctionsHttpProjectOptions.cs
@@ -1,0 +1,31 @@
+﻿using Arcus.Templates.Tests.Integration.Fixture;
+
+namespace Arcus.Templates.Tests.Integration.AzureFunctions.Http
+{
+    /// <summary>
+    /// Represents the additional consumer options for the <see cref="AzureFunctionsHttpProject"/>.
+    /// </summary>
+    public class AzureFunctionsHttpProjectOptions : ProjectOptions
+    {
+        private AzureFunctionsHttpProjectOptions(ProjectOptions existingOptions) : base(existingOptions)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AzureFunctionsHttpProjectOptions" /> class.
+        /// </summary>
+        public AzureFunctionsHttpProjectOptions()
+        {
+        }
+
+        /// <summary>
+        /// Adds the project option to include the health checks Azure Function from the Azure Functions HTTP trigger project.
+        /// </summary>
+        /// <returns></returns>
+        public AzureFunctionsHttpProjectOptions WithIncludeHealthChecks()
+        {
+            ProjectOptions newOptions = AddOption("--include-healthchecks");
+            return new AzureFunctionsHttpProjectOptions(newOptions);
+        }
+    }
+}

--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/Http/AzureFunctionsHttpProjectOptions.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/Http/AzureFunctionsHttpProjectOptions.cs
@@ -21,7 +21,6 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions.Http
         /// <summary>
         /// Adds the project option to include the health checks Azure Function from the Azure Functions HTTP trigger project.
         /// </summary>
-        /// <returns></returns>
         public AzureFunctionsHttpProjectOptions WithIncludeHealthChecks()
         {
             ProjectOptions newOptions = AddOption("--include-healthchecks");

--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/Http/Health/HealthChecksTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/Http/Health/HealthChecksTests.cs
@@ -1,0 +1,95 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Arcus.Templates.Tests.Integration.Fixture;
+using Arcus.Templates.Tests.Integration.WebApi.Health.v1;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Newtonsoft.Json;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Arcus.Templates.Tests.Integration.AzureFunctions.Http.Health
+{
+    [Collection(TestCollections.Integration)]
+    [Trait("Category", TestTraits.Integration)]
+    public class HealthChecksTests
+    {
+        private readonly TestConfig _config;
+        private readonly ITestOutputHelper _outputWriter;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HealthChecksTests" /> class.
+        /// </summary>
+        public HealthChecksTests(ITestOutputHelper outputWriter)
+        {
+            _outputWriter = outputWriter;
+            _config = TestConfig.Create();
+        }
+
+        [Fact]
+        public async Task HttpAzureFunctionsProject_WithIncludeHealthChecks_ContainsHealthChecks()
+        {
+            // Arrange
+            var options =
+                new AzureFunctionsHttpProjectOptions()
+                    .WithIncludeHealthChecks();
+            
+            using (var project = await AzureFunctionsHttpProject.StartNewAsync(_config, options, _outputWriter))
+            {
+                // Act
+                using (HttpResponseMessage response = await project.Health.GetAsync())
+                {
+                    // Assert
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                    Assert.NotEmpty(response.Headers.GetValues("RequestId"));
+                    Assert.NotEmpty(response.Headers.GetValues("X-Transaction-Id"));
+                    
+                    string healthReportJson = await response.Content.ReadAsStringAsync();
+
+                    var healthReport = JsonConvert.DeserializeObject<HealthReport>(healthReportJson, new TimeSpanConverter());
+                    Assert.NotNull(healthReport);
+                    Assert.Equal(HealthStatus.Healthy, healthReport.Status);
+                }
+            }
+        }
+        
+        [Fact]
+        public async Task HttpAzureFunctionsProject_WithIncludeHealthChecks_ChecksAcceptRequestHeader()
+        {
+            // Arrange
+            var options =
+                new AzureFunctionsHttpProjectOptions()
+                    .WithIncludeHealthChecks();
+            
+            using (var project = await AzureFunctionsHttpProject.StartNewAsync(_config, _outputWriter))
+            {
+                // Act
+                using (HttpResponseMessage response = await project.Health.GetAsync(request =>
+                {
+                    request.Headers.Accept.Clear();
+                    request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/pdf"));
+                }))
+                {
+                    // Assert
+                    Assert.Equal(HttpStatusCode.UnsupportedMediaType, response.StatusCode);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task HttpAzureFunctionsProject_WithoutOptions_DoesNotContainHealthChecks()
+        {
+            // Arrange
+            using (var project = await AzureFunctionsHttpProject.StartNewAsync(_config, _outputWriter))
+            {
+                // Act
+                using (HttpResponseMessage response = await project.Health.GetAsync())
+                {
+                    // Assert
+                    Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+                }
+            }
+        }
+    }
+}

--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/Http/Health/HealthChecksTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/Http/Health/HealthChecksTests.cs
@@ -62,7 +62,7 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions.Http.Health
                 new AzureFunctionsHttpProjectOptions()
                     .WithIncludeHealthChecks();
             
-            using (var project = await AzureFunctionsHttpProject.StartNewAsync(_config, _outputWriter))
+            using (var project = await AzureFunctionsHttpProject.StartNewAsync(_config, options, _outputWriter))
             {
                 // Act
                 using (HttpResponseMessage response = await project.Health.GetAsync(request =>

--- a/src/Arcus.Templates.Tests.Integration/WebApi/Health/HealthEndpointService.cs
+++ b/src/Arcus.Templates.Tests.Integration/WebApi/Health/HealthEndpointService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Arcus.Templates.Tests.Integration.Fixture;
 using Arcus.Templates.Tests.Integration.WebApi.Fixture;
@@ -34,7 +35,7 @@ namespace Arcus.Templates.Tests.Integration.WebApi.Health
         /// </summary>
         public async Task<HttpResponseMessage> GetAsync()
         {
-            return await GetAsync(_healthEndpoint);
+            return await GetAsync(_healthEndpoint, request => request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json")));
         }
 
         /// <summary>


### PR DESCRIPTION
Adds an project option `--include-healthchecks` to the Azure Functions HTTP trigger project template to include an Azure Functions that response with the current health status of the running Azure Function.

Closes #398 
Relates to #378