### PR TITLE
feat: Provide support for custom open-api examples for request / response models

### DIFF
--- a/src/Arcus.Templates.WebApi/Controllers/HealthController.cs
+++ b/src/Arcus.Templates.WebApi/Controllers/HealthController.cs
@@ -4,8 +4,11 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using GuardNet;
-#if (ExcludeOpenApi == false && ExcludeCorrelation == false)
+#if (ExcludeOpenApi == false)
+using Arcus.Templates.WebApi.ExampleProviders;
+#if (ExcludeCorrelation == false)
 using Swashbuckle.AspNetCore.Filters;
+#endif
 #endif
 
 namespace Arcus.Templates.WebApi.Controllers
@@ -40,9 +43,12 @@ namespace Arcus.Templates.WebApi.Controllers
         [RequestTracking(500, 599)]
         [ProducesResponseType(typeof(HealthReport), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(HealthReport), StatusCodes.Status503ServiceUnavailable)]
-#if (ExcludeOpenApi == false && ExcludeCorrelation == false)
+#if (ExcludeOpenApi == false)
+#if (ExcludeCorrelation == false)
         [SwaggerResponseHeader(200, "RequestId", "string", "The header that has a request ID that uniquely identifies this operation call")]
         [SwaggerResponseHeader(200, "X-Transaction-Id", "string", "The header that has the transaction ID is used to correlate multiple operation calls.")]
+#endif
+        [SwaggerResponseExample(200, typeof(HealthReportExampleProvider))]
 #endif
         public async Task<IActionResult> Get()
         {

--- a/src/Arcus.Templates.WebApi/ExampleProviders/HealthReportExampleProvider.cs
+++ b/src/Arcus.Templates.WebApi/ExampleProviders/HealthReportExampleProvider.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+using Swashbuckle.AspNetCore.Filters;
+
+namespace Arcus.Templates.WebApi.ExampleProviders
+{
+    public class HealthReportExampleProvider : IExamplesProvider<HealthReport>
+    {
+        public HealthReport GetExamples()
+        {
+            var entries = new Dictionary<string, HealthReportEntry>
+            {
+                ["api"] = new HealthReportEntry(HealthStatus.Healthy, "Api is healthy", TimeSpan.FromMilliseconds(120), null, null)
+            };
+            return new HealthReport(new ReadOnlyDictionary<string, HealthReportEntry>(new Dictionary<string, HealthReportEntry>()), TimeSpan.FromMilliseconds(201));
+        }
+    }
+}
+

--- a/src/Arcus.Templates.WebApi/Startup.cs
+++ b/src/Arcus.Templates.WebApi/Startup.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 #if (ExcludeOpenApi == false)
 using Microsoft.OpenApi.Models;
+using Arcus.Templates.WebApi.ExampleProviders;
 #endif
 #if (ExcludeOpenApi == false && ExcludeCorrelation == false)
 using Swashbuckle.AspNetCore.Filters;
@@ -146,6 +147,7 @@ namespace Arcus.Templates.WebApi
                 swaggerGenerationOptions.SwaggerDoc("v1", openApiInformation);
                 swaggerGenerationOptions.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, "Arcus.Templates.WebApi.Open-Api.xml"));
 
+                swaggerGenerationOptions.ExampleFilters();
 #if (ExcludeCorrelation == false)
                 swaggerGenerationOptions.OperationFilter<AddHeaderOperationFilter>("X-Transaction-Id", "Transaction ID is used to correlate multiple operation calls. A new transaction ID will be generated if not specified.", false);
                 swaggerGenerationOptions.OperationFilter<AddResponseHeadersFilter>();
@@ -220,6 +222,7 @@ namespace Arcus.Templates.WebApi
                 });
 #endif
             });
+            services.AddSwaggerExamplesFromAssemblyOf<HealthReportExampleProvider>();
 //[#endif]
 #endif
         }


### PR DESCRIPTION
Add support to easily provide custom request- and response model examples in the Open API documentation of the API.

Closes #433 and #424
