### PR TITLE
fix: use ubuntu-latest in docker tests

### DIFF
--- a/build/templates/docker-integration-tests.yml
+++ b/build/templates/docker-integration-tests.yml
@@ -7,7 +7,7 @@ stages:
       - job: RunIntegrationTests
         displayName: 'Run integration tests'
         pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: '$(Vm.Image)'
         steps:
           - task: DownloadPipelineArtifact@2
             displayName: 'Download build artifacts'


### PR DESCRIPTION
Use `ubuntu-latest` (via variable) in Docker integration tests.

https://docs.microsoft.com/en-us/azure/devops/release-notes/2021/pipelines/sprint-187-update#ubuntu-1604-will-be-removed-from-microsoft-hosted-pools-in-september-2021