### PR TITLE
feat: upgrade az func http trigger to net6.0

### DIFF
--- a/build/templates/install-azure-functions-core-tools.yml
+++ b/build/templates/install-azure-functions-core-tools.yml
@@ -3,5 +3,5 @@ steps:
       wget -q https://packages.microsoft.com/config/ubuntu/16.04/packages-microsoft-prod.deb
       sudo dpkg -i packages-microsoft-prod.deb
       sudo apt-get update
-      sudo apt-get install azure-functions-core-tools-3
+      sudo apt-get install azure-functions-core-tools-4
     displayName: 'Install Azure Functions Core tools'

--- a/src/Arcus.Templates.AzureFunctions.Http/.template.config/template.json
+++ b/src/Arcus.Templates.AzureFunctions.Http/.template.config/template.json
@@ -104,7 +104,7 @@
       "args": {
         "referenceType": "package",
         "reference": "Microsoft.NET.Sdk.Functions",
-        "version": "3.0.13",
+        "version": "4.0.1",
         "projectFileExtensions": ".csproj"
       }
     }

--- a/src/Arcus.Templates.AzureFunctions.Http/Arcus.Templates.AzureFunctions.Http.csproj
+++ b/src/Arcus.Templates.AzureFunctions.Http/Arcus.Templates.AzureFunctions.Http.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <!--#if (AuthoringMode)-->
     <Authors>Arcus</Authors>

--- a/src/Arcus.Templates.AzureFunctions.Http/Dockerfile
+++ b/src/Arcus.Templates.AzureFunctions.Http/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/azure-functions/dotnet:4 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/core/sdk:6.0.100-buster AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:6.0.100-bullseye-slim AS build
 WORKDIR /src
 COPY ["Arcus.Templates.AzureFunctions.Http.csproj", ""]
 

--- a/src/Arcus.Templates.AzureFunctions.Http/Dockerfile
+++ b/src/Arcus.Templates.AzureFunctions.Http/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/azure-functions/dotnet:3.0 AS base
+FROM mcr.microsoft.com/azure-functions/dotnet:4.0 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1-buster AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:6.0.100-buster AS build
 WORKDIR /src
 COPY ["Arcus.Templates.AzureFunctions.Http.csproj", ""]
 

--- a/src/Arcus.Templates.AzureFunctions.Http/Dockerfile
+++ b/src/Arcus.Templates.AzureFunctions.Http/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/azure-functions/dotnet:4 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/core/sdk:6.0.100-bullseye-slim AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0.100-bullseye-slim AS build
 WORKDIR /src
 COPY ["Arcus.Templates.AzureFunctions.Http.csproj", ""]
 

--- a/src/Arcus.Templates.AzureFunctions.Http/Dockerfile
+++ b/src/Arcus.Templates.AzureFunctions.Http/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/azure-functions/dotnet:4.0 AS base
+FROM mcr.microsoft.com/azure-functions/dotnet:4 AS base
 WORKDIR /app
 EXPOSE 80
 

--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/Http/AzureFunctionsHttpProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/Http/AzureFunctionsHttpProject.cs
@@ -193,7 +193,7 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions.Http
         /// </summary>
         public async Task StartAsync()
         {
-            Run(Configuration.BuildConfiguration, TargetFramework.NetCoreApp31);
+            Run(Configuration.BuildConfiguration, TargetFramework.Net6_0);
             await WaitUntilTriggerIsAvailableAsync(OrderFunctionEndpoint);
         }
     }

--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/Http/Health/HealthChecksTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/Http/Health/HealthChecksTests.cs
@@ -7,7 +7,6 @@ using Arcus.Templates.Tests.Integration.WebApi.Health.v1;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-
 using Xunit;
 using Xunit.Abstractions;
 


### PR DESCRIPTION
Upgrades the Azure Functions HTTP Trigger project template to .NET 6.

Closes #488 