### PR TITLE
chore: upgrade databricks jobmetrics to net6.0

### DIFF
--- a/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/.template.config/template.json
+++ b/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/.template.config/template.json
@@ -69,7 +69,7 @@
       "args": {
         "referenceType": "package",
         "reference": "Microsoft.NET.Sdk.Functions",
-        "version": "3.0.13",
+        "version": "4.0.1",
         "projectFileExtensions": ".csproj"
       }
     }

--- a/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/Arcus.Templates.AzureFunctions.Databricks.JobMetrics.csproj
+++ b/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/Arcus.Templates.AzureFunctions.Databricks.JobMetrics.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <!--#if (AuthoringMode)-->
     <Authors>Arcus</Authors>

--- a/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/Dockerfile
+++ b/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/azure-functions/dotnet:3.0 AS base
+FROM mcr.microsoft.com/azure-functions/dotnet:4 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1-buster AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:6.0.100-bullseye-slim AS build
 WORKDIR /src
 COPY ["Arcus.Templates.AzureFunctions.Databricks.JobMetrics.csproj", ""]
 

--- a/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/Dockerfile
+++ b/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/azure-functions/dotnet:4 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/core/sdk:6.0.100-bullseye-slim AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0.100-bullseye-slim AS build
 WORKDIR /src
 COPY ["Arcus.Templates.AzureFunctions.Databricks.JobMetrics.csproj", ""]
 

--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/Databricks/JobMetrics/AzureFunctionsDatabricksProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/Databricks/JobMetrics/AzureFunctionsDatabricksProject.cs
@@ -64,7 +64,7 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions.Databricks.JobMetrics
 
         private void Start()
         {
-            Run(BuildConfiguration.Debug, TargetFramework.NetCoreApp31);
+            Run(BuildConfiguration.Debug, TargetFramework.Net6_0);
         }
 
         private void AddDatabricksSecurityToken(string securityToken)


### PR DESCRIPTION
Upgrade the Azure Functions Databricks JobMetrics project to .NET 6.

Relates to https://github.com/arcus-azure/arcus/issues/106