### PR TITLE
chore: inform testers about az func tools

### DIFF
--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/AzureFunctionsProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/AzureFunctionsProject.cs
@@ -121,7 +121,7 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions
             return new CannotStartTemplateProjectException(
                 "Could start test project based on Azure Functions project template due to an exception occurred during the build/run process, "
                 + "please check if the Azure Functions Core Tools (https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local) are installed and are available through the PATH environment variable, "
-                + "or possible check for any compile errors or runtime failures in the created test project based on the project template", exception);
+                + "or possible check for any compile errors or runtime failures (via the 'TearDownOptions') in the created test project based on the project template", exception);
         }
 
         /// <summary>

--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/AzureFunctionsProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/AzureFunctionsProject.cs
@@ -111,7 +111,19 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions
             Environment.SetEnvironmentVariable(ApplicationInsightsInstrumentationKeyVariable, ApplicationInsightsConfig.InstrumentationKey);
             return processInfo;
         }
-        
+
+        /// <summary>
+        /// Creates an user-friendly exception based on an occurred <paramref name="exception"/> to show and help the tester pinpoint the problem.
+        /// </summary>
+        /// <param name="exception">The occurred exception during the startup process of the test project based on the project template.</param>
+        protected override CannotStartTemplateProjectException CreateProjectStartupFailure(Exception exception)
+        {
+            return new CannotStartTemplateProjectException(
+                "Could start test project based on Azure Functions project template due to an exception occurred during the build/run process, "
+                + "please check if the Azure Functions Core Tools (https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local) are installed and are available through the PATH environment variable, "
+                + "or possible check for any compile errors or runtime failures in the created test project based on the project template", exception);
+        }
+
         /// <summary>
         /// Waits until the Azure Function project is fully running and ready to be interacted with.
         /// </summary>

--- a/src/Arcus.Templates.Tests.Integration/Fixture/TemplateProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/Fixture/TemplateProject.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -237,11 +238,18 @@ namespace Arcus.Templates.Tests.Integration.Fixture
 
             commandArguments = commandArguments ?? new CommandArgument[0];
 
-            ProcessStartInfo processInfo = PrepareProjectRun(buildConfiguration, targetFramework, commandArguments);
-            _process.StartInfo = processInfo;
+            try
+            {
+                ProcessStartInfo processInfo = PrepareProjectRun(buildConfiguration, targetFramework, commandArguments);
+                _process.StartInfo = processInfo;
 
-            _started = true;
-            _process.Start();
+                _started = true;
+                _process.Start();
+            }
+            catch (Exception exception)
+            {
+                throw CreateProjectStartupFailure(exception);
+            }
         }
 
         /// <summary>
@@ -273,6 +281,17 @@ namespace Arcus.Templates.Tests.Integration.Fixture
             };
 
             return processInfo;
+        }
+
+        /// <summary>
+        /// Creates an user-friendly exception based on an occurred <paramref name="exception"/> to show and help the tester pinpoint the problem.
+        /// </summary>
+        /// <param name="exception">The occurred exception during the startup process of the test project based on the project template.</param>
+        protected virtual CannotStartTemplateProjectException CreateProjectStartupFailure(Exception exception)
+        {
+            return new CannotStartTemplateProjectException(
+                "Could start test project based on project template due to an exception occurred during the build/run process, " 
+                + "please check for any compile errors or runtime failures (via the 'TearDownOptions') in the created test project based on the project template", exception);
         }
 
         /// <summary>


### PR DESCRIPTION
Adds extra user-friendly exception message to inform users for possible missing tools or failures in the created test project based on the project template.

Closes #503 