### PR TITLE
chore: renovate ignore docs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
     "default:disablePrControls"
   ],
   "ignorePaths": [
-    "/docs/**"
+    "**/docs/**"
   ],
   "nuget": {
     "enabled": true


### PR DESCRIPTION
Ignoring the `/docs` folder in Renovate bot. 