### PR TITLE
fix: use http-specific correlation in az func http trigger

### DIFF
--- a/src/Arcus.Templates.AzureFunctions.Http/Startup.cs
+++ b/src/Arcus.Templates.AzureFunctions.Http/Startup.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Arcus.Security.Core.Caching.Configuration;
 using Arcus.Templates.AzureFunctions.Http;
+using Arcus.WebApi.Logging.Core.Correlation;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -35,7 +36,7 @@ namespace Arcus.Templates.AzureFunctions.Http
         {
             IConfiguration config = builder.GetContext().Configuration;
 
-            builder.AddHttpCorrelation();
+            builder.AddHttpCorrelation((HttpCorrelationInfoOptions options) => { });
 #if IncludeHealthChecks
             builder.Services.AddHealthChecks();
 #endif


### PR DESCRIPTION
Since we updated the Azure Functions extensions to use HTTP-specific correlation options instead, we should update the registration in our Azure Functions HTTP trigger.