### PR TITLE
fix: use correct appinsights instrumentation key env var

### DIFF
--- a/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/Startup.cs
+++ b/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/Startup.cs
@@ -39,7 +39,7 @@ namespace Arcus.Templates.AzureFunctions.Databricks.JobMetrics
                 stores.AddAzureKeyVaultWithManagedIdentity("https://your-keyvault.vault.azure.net/", CacheConfiguration.Default);
             });
 
-            var instrumentationKey = config.GetValue<string>("APPLICATIONINSIGHTS_INSTRUMENTATIONKEY");
+            var instrumentationKey = config.GetValue<string>("APPINSIGHTS_INSTRUMENTATIONKEY");
             var configuration = new LoggerConfiguration()
                 .MinimumLevel.Debug()
                 .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
@@ -51,8 +51,7 @@ namespace Arcus.Templates.AzureFunctions.Databricks.JobMetrics
 
             builder.Services.AddLogging(logging =>
             {
-                logging.ClearProvidersExceptFunctionProviders()
-                       .AddSerilog(configuration.CreateLogger(), dispose: true);
+                logging.AddSerilog(configuration.CreateLogger(), dispose: true);
             });
         }
     }

--- a/src/Arcus.Templates.AzureFunctions.Http/Startup.cs
+++ b/src/Arcus.Templates.AzureFunctions.Http/Startup.cs
@@ -52,7 +52,7 @@ namespace Arcus.Templates.AzureFunctions.Http
                 stores.AddAzureKeyVaultWithManagedIdentity("https://your-keyvault.vault.azure.net/", CacheConfiguration.Default);
             });
 
-            var instrumentationKey = config.GetValue<string>("APPLICATIONINSIGHTS_INSTRUMENTATIONKEY");
+            var instrumentationKey = config.GetValue<string>("APPINSIGHTS_INSTRUMENTATIONKEY");
             var configuration = new LoggerConfiguration()
                 .MinimumLevel.Debug()
                 .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
@@ -64,8 +64,7 @@ namespace Arcus.Templates.AzureFunctions.Http
 
             builder.Services.AddLogging(logging =>
             {
-                logging.ClearProvidersExceptFunctionProviders()
-                       .AddSerilog(configuration.CreateLogger(), dispose: true);
+                logging.AddSerilog(configuration.CreateLogger(), dispose: true);
             });
         }
     }

--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/AzureFunctionsProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/AzureFunctionsProject.cs
@@ -19,7 +19,7 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions
     /// </summary>
     public abstract class AzureFunctionsProject : TemplateProject
     {
-        protected const string ApplicationInsightsInstrumentationKeyVariable = "APPLICATIONINSIGHTS_INSTRUMENTATIONKEY";
+        protected const string ApplicationInsightsInstrumentationKeyVariable = "APPINSIGHTS_INSTRUMENTATIONKEY";
 
         private static readonly HttpClient HttpClient = new HttpClient();
         


### PR DESCRIPTION
Use 'APPINSIGHTS_INSTRUMENTATIONKEY' as environment variable to set instrumentation key.

Closes #547
Closes #528