### PR TITLE
chore: add readme and proj url to nuget pkg

### DIFF
--- a/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/Arcus.Templates.AzureFunctions.Databricks.JobMetrics.csproj
+++ b/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/Arcus.Templates.AzureFunctions.Databricks.JobMetrics.csproj
@@ -15,7 +15,7 @@
     <PackageTags>Azure;Azure Functions;Databricks;Metric</PackageTags>
     <Copyright>Copyright (c) Arcus</Copyright>
     <PackageLicenseUrl>https://github.com/arcus-azure/arcus.templates/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/arcus-azure/arcus.templates</PackageProjectUrl>
+    <PackageProjectUrl>https://templates.arcus-azure.net/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.templates</RepositoryUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -40,7 +40,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="Dockerfile" />
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <!--#endif-->
 

--- a/src/Arcus.Templates.AzureFunctions.Http/Arcus.Templates.AzureFunctions.Http.csproj
+++ b/src/Arcus.Templates.AzureFunctions.Http/Arcus.Templates.AzureFunctions.Http.csproj
@@ -15,7 +15,7 @@
     <PackageTags>Azure;Azure Functions;HTTP;API</PackageTags>
     <Copyright>Copyright (c) Arcus</Copyright>
     <PackageLicenseUrl>https://github.com/arcus-azure/arcus.templates/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/arcus-azure/arcus.templates</PackageProjectUrl>
+    <PackageProjectUrl>https://templates.arcus-azure.net/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.templates</RepositoryUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -41,7 +41,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="Dockerfile" />
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <!--#endif-->
 

--- a/src/Arcus.Templates.AzureFunctions.ServiceBus.Queue/Arcus.Templates.AzureFunctions.ServiceBus.Queue.csproj
+++ b/src/Arcus.Templates.AzureFunctions.ServiceBus.Queue/Arcus.Templates.AzureFunctions.ServiceBus.Queue.csproj
@@ -15,7 +15,7 @@
     <PackageTags>Azure;Azure Functions;Service Bus;Queue</PackageTags>
     <Copyright>Copyright (c) Arcus</Copyright>
     <PackageLicenseUrl>https://github.com/arcus-azure/arcus.templates/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/arcus-azure/arcus.templates</PackageProjectUrl>
+    <PackageProjectUrl>https://templates.arcus-azure.net/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.templates</RepositoryUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -37,6 +37,10 @@
     <DefineConstants>$(DefineConstants);</DefineConstants>
     <DockerFastModeProjectMountDirectory>/home/site/wwwroot</DockerFastModeProjectMountDirectory>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
   <!--#endif-->
   
   <ItemGroup>

--- a/src/Arcus.Templates.ServiceBus.Queue/Arcus.Templates.ServiceBus.Queue.csproj
+++ b/src/Arcus.Templates.ServiceBus.Queue/Arcus.Templates.ServiceBus.Queue.csproj
@@ -15,7 +15,7 @@
     <PackageTags>Worker;Azure;Azure;ServiceBus;Queue</PackageTags>
     <Copyright>Copyright (c) Arcus</Copyright>
     <PackageLicenseUrl>https://github.com/arcus-azure/arcus.templates/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/arcus-azure/arcus.templates</PackageProjectUrl>
+    <PackageProjectUrl>https://templates.arcus-azure.net/</PackageProjectUrl>
     <PackageTags>Worker;Azure;ServiceBus;Queue</PackageTags>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.templates</RepositoryUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
@@ -42,7 +42,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="Dockerfile" />
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <!--#endif-->
 

--- a/src/Arcus.Templates.ServiceBus.Topic/Arcus.Templates.ServiceBus.Topic.csproj
+++ b/src/Arcus.Templates.ServiceBus.Topic/Arcus.Templates.ServiceBus.Topic.csproj
@@ -15,7 +15,7 @@
     <PackageTags>Worker;Azure;Azure;ServiceBus;Topic</PackageTags>
     <Copyright>Copyright (c) Arcus</Copyright>
     <PackageLicenseUrl>https://github.com/arcus-azure/arcus.templates/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/arcus-azure/arcus.templates</PackageProjectUrl>
+    <PackageProjectUrl>https://templates.arcus-azure.net/</PackageProjectUrl>
     <PackageTags>Worker;Azure;ServiceBus;Topic</PackageTags>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.templates</RepositoryUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
@@ -42,7 +42,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="Dockerfile" />
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <!--#endif-->
 

--- a/src/Arcus.Templates.WebApi/Arcus.Templates.WebApi.csproj
+++ b/src/Arcus.Templates.WebApi/Arcus.Templates.WebApi.csproj
@@ -17,7 +17,7 @@
     <PackageTags>Azure;WebAPI;App Services;Web App;Web;API</PackageTags>
     <Copyright>Copyright (c) Arcus</Copyright>
     <PackageLicenseUrl>https://github.com/arcus-azure/arcus.templates/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageProjectUrl>https://github.com/arcus-azure/arcus.templates</PackageProjectUrl>
+    <PackageProjectUrl>https://templates.arcus-azure.net/</PackageProjectUrl>
     <PackageTags>Azure;WebAPI;App Services;Web App;Web;API</PackageTags>
     <RepositoryUrl>https://github.com/arcus-azure/arcus.templates</RepositoryUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png</PackageIconUrl>
@@ -43,6 +43,10 @@
     <ExcludeCorrelation>false</ExcludeCorrelation>
     <ExcludeOpenApi>false</ExcludeOpenApi>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
   <!--#endif-->
 
   <ItemGroup Condition="'$(AppSettings)' == 'true'">


### PR DESCRIPTION
Adds the GitHub README file to the NuGet package generation of the projects.
Adds feature docs project URL instead of GitHub URL to NuGet package.

Relates to arcus-azure/arcus#209
Relates to arcus-azure/arcus#208