### PR TITLE
fix: remove unnecessary 'keep directory' tear down option

### DIFF
--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/ServiceBus/Logging/SerilogLoggingTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/ServiceBus/Logging/SerilogLoggingTests.cs
@@ -30,7 +30,6 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions.ServiceBus.Logging
 
             await using (var project = await AzureFunctionsServiceBusProject.StartNewQueueProjectAsync(options, config, _outputWriter))
             {
-                project.TearDownOptions = TearDownOptions.KeepProjectDirectory;
                 // Act / Assert
                 await project.MessagePump.SimulateMessageProcessingAsync();
 


### PR DESCRIPTION
Integration test had (still) an unnecessary tear down option set that was a left-over from local testing.

Follow-up of #578 