### PR TITLE
feat: exclude serilog proj option for az func servicebus topic

### DIFF
--- a/src/Arcus.Templates.AzureFunctions.ServiceBus.Topic/.template.config/ide.host.json
+++ b/src/Arcus.Templates.AzureFunctions.ServiceBus.Topic/.template.config/ide.host.json
@@ -9,5 +9,12 @@
   "learnMoreLink": "https://templates.arcus-azure.net/features/servicebus-topic-azurefunctions-template",
   "icon": "icon.jpg",
   "symbolInfo": [
+    {
+      "id": "exclude-serilog",
+      "name": {
+        "text": "Exclude Serilog"
+      },
+      "isVisible": true
+    }
   ]
 }

--- a/src/Arcus.Templates.AzureFunctions.ServiceBus.Topic/.template.config/template.json
+++ b/src/Arcus.Templates.AzureFunctions.ServiceBus.Topic/.template.config/template.json
@@ -62,6 +62,16 @@
         "value": "#error"
       },
       "replaces": "//#error"
+    },
+    "exclude-serilog": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Exclude the Serilog logging infrastructure in the worker project"
+    },
+    "Serilog": {
+      "type": "computed",
+      "value": "!(exclude-serilog)"
     }
   },
   "postActions": [

--- a/src/Arcus.Templates.AzureFunctions.ServiceBus.Topic/Arcus.Templates.AzureFunctions.ServiceBus.Topic.csproj
+++ b/src/Arcus.Templates.AzureFunctions.ServiceBus.Topic/Arcus.Templates.AzureFunctions.ServiceBus.Topic.csproj
@@ -26,7 +26,6 @@
     <NoWarn>NU5048;NU5125;NU5119</NoWarn>
     <!--#endif-->
   </PropertyGroup>
-
   <!--#if (AuthoringMode)-->
   <ItemGroup>
     <Content Include="**\*" Exclude="**\bin\**\*;**\obj\**\*;**\.vs\**\*;**\launchSettings.json" />
@@ -34,22 +33,27 @@
 
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);</DefineConstants>
+    <Serilog>true</Serilog>
     <DockerFastModeProjectMountDirectory>/home/site/wwwroot</DockerFastModeProjectMountDirectory>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
   <!--#endif-->
   
   <ItemGroup>
     <PackageReference Include="Arcus.Messaging.Abstractions.ServiceBus" Version="1.2.0" />
     <PackageReference Include="Arcus.Messaging.AzureFunctions.ServiceBus" Version="1.2.0" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="2.3.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="2.4.0" Condition="'$(Serilog)' == 'true'" />
     <PackageReference Include="Arcus.Security.AzureFunctions" Version="1.7.0" />
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.7.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.3.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.14.0" />
-    <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="4.2.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+    <PackageReference Include="Serilog" Version="2.11.0" Condition="'$(Serilog)' == 'true'" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="4.2.0" Condition="'$(Serilog)' == 'true'" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" Condition="'$(Serilog)' == 'true'" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Arcus.Templates.AzureFunctions.ServiceBus.Topic/Startup.cs
+++ b/src/Arcus.Templates.AzureFunctions.ServiceBus.Topic/Startup.cs
@@ -5,12 +5,14 @@ using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+#if Serilog
 using Serilog;
 using Serilog.Configuration;
-using Serilog.Events;
-
+using Serilog.Events; 
+#endif
+ 
 [assembly: FunctionsStartup(typeof(Startup))]
-
+ 
 namespace Arcus.Templates.AzureFunctions.ServiceBus.Topic
 {
     public class Startup : FunctionsStartup
@@ -20,7 +22,7 @@ namespace Arcus.Templates.AzureFunctions.ServiceBus.Topic
         {
             builder.ConfigurationBuilder.AddEnvironmentVariables();
         }
-
+        
         /// <summary>
         /// This method gets called by the runtime. Use this method to add services to the container.
         /// </summary>
@@ -36,17 +38,20 @@ namespace Arcus.Templates.AzureFunctions.ServiceBus.Topic
                 //#error Please provide a valid secret provider, for example Azure Key Vault: https://security.arcus-azure.net/features/secret-store/provider/key-vault
                 stores.AddAzureKeyVaultWithManagedIdentity("https://your-keyvault.vault.azure.net/", CacheConfiguration.Default);
             });
-
+            
             builder.AddServiceBusMessageRouting()
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
-
+#if Serilog
+            
             LoggerConfiguration logConfig = CreateLoggerConfiguration(builder);
             builder.Services.AddLogging(logging =>
             {
                 logging.AddSerilog(logConfig.CreateLogger(), dispose: true);
-            });
+            }); 
+#endif
         }
-
+#if Serilog
+        
         private static LoggerConfiguration CreateLoggerConfiguration(IFunctionsHostBuilder builder)
         {
             var logConfig = new LoggerConfiguration()
@@ -65,6 +70,7 @@ namespace Arcus.Templates.AzureFunctions.ServiceBus.Topic
             }
 
             return logConfig;
-        }
+        } 
+#endif
     }
 }

--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/ServiceBus/AzureFunctionsServiceBusProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/ServiceBus/AzureFunctionsServiceBusProject.cs
@@ -11,6 +11,7 @@ using Azure;
 using Azure.Messaging.ServiceBus;
 using Azure.Messaging.ServiceBus.Administration;
 using GuardNet;
+using Microsoft.Extensions.Logging;
 using Xunit.Abstractions;
 
 namespace Arcus.Templates.Tests.Integration.AzureFunctions.ServiceBus
@@ -41,57 +42,54 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions.ServiceBus
         public MessagePumpService MessagePump { get; }
 
         /// <summary>
-        /// Starts a newly created project from the Azure Functions Service Bus Queue project template.
+        /// Starts a newly created project from the Azure Functions Service Bus project template.
         /// </summary>
-        /// <param name="configuration">The collection of configuration values to correctly initialize the resulting project with secret values.</param>
-        /// <param name="outputWriter">The output logger to add telemetry information during the creation and startup process.</param>
-        /// <returns>
-        ///     An Azure Functions Service Bus Queue project with a set of services to interact with the worker.
-        /// </returns>
-        public static async Task<AzureFunctionsServiceBusProject> StartNewQueueProjectAsync(TestConfig configuration, ITestOutputHelper outputWriter)
-        {
-            Guard.NotNull(outputWriter, nameof(outputWriter), "Requires a test logger to write diagnostic information during the creation and startup process");
-
-            return await StartNewQueueProjectAsync(new AzureFunctionsServiceBusProjectOptions(), configuration, outputWriter);
-        }
-
-        /// <summary>
-        /// Starts a newly created project from the Azure Functions Service Bus Queue project template.
-        /// </summary>
-        /// <param name="options">The additional project options to pass along to the project creation command.</param>
-        /// <param name="configuration">The collection of configuration values to correctly initialize the resulting project with secret values.</param>
-        /// <param name="outputWriter">The output logger to add telemetry information during the creation and startup process.</param>
-        /// <returns>
-        ///     An Azure Functions Service Bus Queue project with a set of services to interact with the worker.
-        /// </returns>
-        public static async Task<AzureFunctionsServiceBusProject> StartNewQueueProjectAsync(
-            AzureFunctionsServiceBusProjectOptions options, 
-            TestConfig configuration, 
-            ITestOutputHelper outputWriter)
-        {
-            Guard.NotNull(outputWriter, nameof(outputWriter), "Requires a test logger to write diagnostic information during the creation and startup process");
-
-            AzureFunctionsServiceBusProject project = CreateNew(ServiceBusEntity.Queue, options, configuration, outputWriter);
-
-            await project.StartAsync(ServiceBusEntity.Queue);
-            return project;
-        }
-
-        /// <summary>
-        /// Starts a newly created project from the Azure Functions Service Bus Topic project template.
-        /// </summary>
+        /// <param name="entity">The type of the Azure Service Bus entity, to control the used project template.</param>
         /// <param name="configuration">The collection of configuration values to correctly initialize the resulting project with secret values.</param>
         /// <param name="outputWriter">The output logger to add telemetry information during the creation and startup process.</param>
         /// <returns>
         ///     An Azure Functions Service Bus Topic project with a set of services to interact with the worker.
         /// </returns>
-        public static async Task<AzureFunctionsServiceBusProject> StartNewTopicProjectAsync(TestConfig configuration, ITestOutputHelper outputWriter)
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when the <paramref name="configuration"/>, or the <paramref name="outputWriter"/> is <c>null</c>.
+        /// </exception>
+        public static async Task<AzureFunctionsServiceBusProject> StartNewProjectAsync(
+            ServiceBusEntity entity,
+            TestConfig configuration,
+            ITestOutputHelper outputWriter)
         {
+            Guard.NotNull(configuration, nameof(configuration), "Requires a configuration instance to retrieve the configuration values to pass along to the to-be-created project");
             Guard.NotNull(outputWriter, nameof(outputWriter), "Requires a test logger to write diagnostic information during the creation and startup process");
 
-            AzureFunctionsServiceBusProject project = CreateNew(ServiceBusEntity.Topic, new AzureFunctionsServiceBusProjectOptions(), configuration, outputWriter);
+            return await StartNewProjectAsync(entity, new AzureFunctionsServiceBusProjectOptions(), configuration, outputWriter);
+        }
 
-            await project.StartAsync(ServiceBusEntity.Topic);
+        /// <summary>
+        /// Starts a newly created project from the Azure Functions Service Bus project template.
+        /// </summary>
+        /// <param name="entity">The type of the Azure Service Bus entity, to control the used project template.</param>
+        /// <param name="options">The additional project options to pass along to the project creation command.</param>
+        /// <param name="configuration">The collection of configuration values to correctly initialize the resulting project with secret values.</param>
+        /// <param name="outputWriter">The output logger to add telemetry information during the creation and startup process.</param>
+        /// <returns>
+        ///     An Azure Functions Service Bus Topic project with a set of services to interact with the worker.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when the <paramref name="options"/>, the <paramref name="configuration"/>, or the <paramref name="outputWriter"/> is <c>null</c>.
+        /// </exception>
+        public static async Task<AzureFunctionsServiceBusProject> StartNewProjectAsync(
+            ServiceBusEntity entity,
+            AzureFunctionsServiceBusProjectOptions options,
+            TestConfig configuration,
+            ITestOutputHelper outputWriter)
+        {
+            Guard.NotNull(options, nameof(options), "Requires a set of project options to pass along to the project creation command");
+            Guard.NotNull(configuration, nameof(configuration), "Requires a configuration instance to retrieve the configuration values to pass along to the to-be-created project");
+            Guard.NotNull(outputWriter, nameof(outputWriter), "Requires a test logger to write diagnostic information during the creation and startup process");
+
+            AzureFunctionsServiceBusProject project = CreateNew(entity, options, configuration, outputWriter);
+
+            await project.StartAsync(entity);
             return project;
         }
 

--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/ServiceBus/Logging/SerilogLoggingTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/ServiceBus/Logging/SerilogLoggingTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Arcus.Templates.Tests.Integration.Fixture;
+using Arcus.Templates.Tests.Integration.Worker;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -19,8 +20,10 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions.ServiceBus.Logging
             _outputWriter = outputWriter;
         }
 
-        [Fact]
-        public async Task ServiceBusQueueProject_WithoutSerilog_CorrectlyProcessesMessage()
+        [Theory]
+        [InlineData(ServiceBusEntity.Queue)]
+        [InlineData(ServiceBusEntity.Topic)]
+        public async Task ServiceBusProject_WithoutSerilog_CorrectlyProcessesMessage(ServiceBusEntity entity)
         {
             // Arrange
             var config = TestConfig.Create();
@@ -28,9 +31,8 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions.ServiceBus.Logging
                 new AzureFunctionsServiceBusProjectOptions()
                     .WithExcludeSerilog();
 
-            await using (var project = await AzureFunctionsServiceBusProject.StartNewQueueProjectAsync(options, config, _outputWriter))
+            await using (var project = await AzureFunctionsServiceBusProject.StartNewProjectAsync(entity, options, config, _outputWriter))
             {
-                project.TearDownOptions = TearDownOptions.KeepProjectDirectory;
                 // Act / Assert
                 await project.MessagePump.SimulateMessageProcessingAsync();
 

--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/ServiceBus/MessageHandling/OrderMessageHandlerTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/ServiceBus/MessageHandling/OrderMessageHandlerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Arcus.Templates.Tests.Integration.Fixture;
+using Arcus.Templates.Tests.Integration.Worker;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -19,24 +20,14 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions.ServiceBus.MessageHan
             _outputWriter = outputWriter;
         }
 
-        [Fact]
-        public async Task ServiceBusQueueProject_WithOrderMessageHandlerImplementation_CorrectlyProcessesMessage()
+        [Theory]
+        [InlineData(ServiceBusEntity.Queue)]
+        [InlineData(ServiceBusEntity.Topic)]
+        public async Task ServiceBusProject_WithOrderMessageHandlerImplementation_CorrectlyProcessesMessage(ServiceBusEntity entity)
         {
             // Arrange
             var config = TestConfig.Create();
-            await using (var project = await AzureFunctionsServiceBusProject.StartNewQueueProjectAsync(config, _outputWriter))
-            {
-                // Act / Assert
-                await project.MessagePump.SimulateMessageProcessingAsync();
-            }
-        }
-
-        [Fact]
-        public async Task ServiceBusTopicProject_WithOrderMessageHandlerImplementation_CorrectlyProcessesMessage()
-        {
-            // Arrange
-            var config = TestConfig.Create();
-            await using (var project = await AzureFunctionsServiceBusProject.StartNewTopicProjectAsync(config, _outputWriter))
+            await using (var project = await AzureFunctionsServiceBusProject.StartNewProjectAsync(entity, config, _outputWriter))
             {
                 // Act / Assert
                 await project.MessagePump.SimulateMessageProcessingAsync();


### PR DESCRIPTION
Add project option to exclude Serilog logging from the Azure Functions Service Bus topic project temlate.

Closes #551