### PR TITLE
feat: add healthreport json to webapi template

### DIFF
--- a/docs/preview/features/web-api-template.md
+++ b/docs/preview/features/web-api-template.md
@@ -49,3 +49,11 @@ As part of this template the following HTTP header(s) are removed for security s
 * `Server` header * Provides information concerning the Web API runtime
 
 The OpenAPI documentation is available by-default. Be careful of exposing sensitive information with the OpenAPI documentation, only expose what's necessary and hide everything else.
+
+### Health
+
+A default health controller is available that exposes the configured health checks as an aggregated health report. 
+For more information on application health, see [Microsoft's documentation](https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/health-checks).
+
+The controller doesn't directly exposes Microsoft's `HealthReport` model but uses a custom `HealthReportJson` operation model which eliminates the exception details from the original report.
+This way the application's health can be exposed in a safe manner without also exposing exception and assembly information to the user.

--- a/src/Arcus.Templates.WebApi/Controllers/HealthController.cs
+++ b/src/Arcus.Templates.WebApi/Controllers/HealthController.cs
@@ -39,8 +39,8 @@ namespace Arcus.Templates.WebApi.Controllers
         /// <response code="503">API is unhealthy or in degraded state</response>
         [HttpGet(Name = "Health_Get")]
         [RequestTracking(500, 599)]
-        [ProducesResponseType(typeof(HealthReport), StatusCodes.Status200OK)]
-        [ProducesResponseType(typeof(HealthReport), StatusCodes.Status503ServiceUnavailable)]
+        [ProducesResponseType(typeof(HealthReportJson), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(HealthReportJson), StatusCodes.Status503ServiceUnavailable)]
 #if (ExcludeOpenApi == false)
 #if (ExcludeCorrelation == false)
         [SwaggerResponseHeader(200, "RequestId", "string", "The header that has a request ID that uniquely identifies this operation call")]
@@ -51,14 +51,15 @@ namespace Arcus.Templates.WebApi.Controllers
         public async Task<IActionResult> Get()
         {
             HealthReport healthReport = await _healthCheckService.CheckHealthAsync();
-            
-            if (healthReport?.Status == HealthStatus.Healthy)
+            HealthReportJson json = HealthReportJson.FromHealthReport(healthReport);
+
+            if (healthReport.Status == HealthStatus.Healthy)
             {
-                return Ok(healthReport);
+                return Ok(json);
             }
             else
             {
-                return StatusCode(StatusCodes.Status503ServiceUnavailable, healthReport);
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, json);
             }
         }
     }

--- a/src/Arcus.Templates.WebApi/ExampleProviders/HealthReportResponseExampleProvider.cs
+++ b/src/Arcus.Templates.WebApi/ExampleProviders/HealthReportResponseExampleProvider.cs
@@ -9,23 +9,38 @@ namespace Arcus.Templates.WebApi.ExampleProviders
     /// <summary>
     /// Generates an example response object for the health API endpoint that will be included in the OpenAPI documentation.
     /// </summary>
-    public class HealthReportResponseExampleProvider : IExamplesProvider<HealthReport>
+    public class HealthReportResponseExampleProvider : IExamplesProvider<HealthReportJson>
     {
         /// <summary>
-        /// Build the HealthReport response example
+        /// Build the <see cref="HealthReportJson"/> response example
         /// </summary>
-        /// <returns>A populated HealthReport object that acts as the example included in the OpenAPI documentation.</returns>
-        public HealthReport GetExamples()
+        /// <returns>A populated <see cref="HealthReportJson"/> object that acts as the example included in the OpenAPI documentation.</returns>
+        public HealthReportJson GetExamples()
         {
-            var entries = new Dictionary<string, HealthReportEntry>
+            var healthyApiEntry = new HealthReportEntryJson()
             {
-                ["api"] = new HealthReportEntry(status: HealthStatus.Healthy, description: "Api is healthy", duration: TimeSpan.FromMilliseconds(33), null, null),
-                ["database"]= new HealthReportEntry(status: HealthStatus.Healthy, description: "Database is available", duration: TimeSpan.FromMilliseconds(123), null, null),
+                Status = HealthStatus.Healthy,
+                Description = "Api is healthy",
+                Duration = TimeSpan.FromMilliseconds(33)
+            };
+            var healthyDatabaseEntry = new HealthReportEntryJson()
+            {
+                Status = HealthStatus.Healthy,
+                Description = "Database is available",
+                Duration = TimeSpan.FromMilliseconds(123)
             };
 
-            var healthReportEntries = new ReadOnlyDictionary<string, HealthReportEntry>(entries);
+            var entries = new Dictionary<string, HealthReportEntryJson>
+            {
+                ["api"] = healthyApiEntry,
+                ["database"]= healthyDatabaseEntry,
+            };
 
-            return new HealthReport(entries: healthReportEntries, totalDuration: TimeSpan.FromMilliseconds(201));
+            return new HealthReportJson()
+            {
+                Entries = new ReadOnlyDictionary<string, HealthReportEntryJson>(entries),
+                TotalDuration = TimeSpan.FromMilliseconds(201)
+            };
         }
     }
 }

--- a/src/Arcus.Templates.WebApi/Serialization/HealthReportEntryJson.cs
+++ b/src/Arcus.Templates.WebApi/Serialization/HealthReportEntryJson.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.Diagnostics.HealthChecks
+{
+    /// <summary>
+    /// Represents an entry in a <see cref="HealthReportJson"/>.
+    /// Corresponds to the result of a single <see cref="IHealthCheck"/>.
+    /// </summary>
+    public struct HealthReportEntryJson
+    {
+        /// <summary>
+        /// Gets additional key-value pairs describing the health of the component.
+        /// </summary>
+        public IDictionary<string, object> Data { get; set; }
+
+        /// <summary>
+        /// Gets a human-readable description of the status of the component that was checked.
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Gets the health check execution duration.
+        /// </summary>
+        public TimeSpan Duration { get; set; }
+
+        /// <summary>
+        /// Gets the health status of the component that was checked.
+        /// </summary>
+        public HealthStatus Status { get; set; }
+
+        /// <summary>
+        /// Gets the tags associated with the health check.
+        /// </summary>
+        public IEnumerable<string> Tags { get; set; }
+
+        /// <summary>
+        /// Creates a JSON data-transfer object from the given Microsoft <see cref="HealthReportEntry"/> <paramref name="entry"/>.
+        /// </summary>
+        /// <param name="entry">The entry of the created health report, representing a single <see cref="IHealthCheck"/> with exception details.</param>
+        public static HealthReportEntryJson FromHealthReportEntry(HealthReportEntry entry)
+        {
+            return new HealthReportEntryJson
+            {
+                Data = entry.Data.ToDictionary(item => item.Key, item => item.Value),
+                Description = entry.Description,
+                Duration = entry.Duration,
+                Status = entry.Status,
+                Tags = entry.Tags
+            };
+        }
+
+        /// <summary>
+        /// Creates a Microsoft <see cref="HealthReportEntry"/> from the given JSON data-transfer object <paramref name="entry"/>.
+        /// </summary>
+        /// <param name="entry">The JSON data-transfer object, representing a single <see cref="IHealthCheck"/> without the exception details.</param>
+        public static HealthReportEntry ToHealthReportEntry(HealthReportEntryJson entry)
+        {
+            return new HealthReportEntry(
+                entry.Status,
+                entry.Description,
+                entry.Duration,
+                exception: null,
+                new ReadOnlyDictionary<string, object>(entry.Data),
+                entry.Tags);
+        }
+    }
+}

--- a/src/Arcus.Templates.WebApi/Serialization/HealthReportJson.cs
+++ b/src/Arcus.Templates.WebApi/Serialization/HealthReportJson.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using GuardNet;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Extensions.Diagnostics.HealthChecks
+{
+    /// <summary>
+    /// Represents an alternative <see cref="HealthReport"/> model without the exception details so it can be exposed safely with OpenAPI.
+    /// </summary>
+    /// <remarks>
+    ///     This model should not be used within the domain and is just available for the serialization between trust boundaries.
+    ///     Use the <see cref="FromHealthReport"/> and <see cref="ToHealthReport"/> to switch between the two.
+    /// </remarks>
+    public class HealthReportJson
+    {
+        /// <summary>
+        /// Gets a dictionary containing the results from each health check.
+        /// </summary>
+        public IDictionary<string, HealthReportEntryJson> Entries { get; set; }
+
+        /// <summary>
+        /// Gets a <see cref="HealthStatus"/> representing the aggregate status of all the health checks.
+        /// The value of <see cref="Status"/> will be the most severe status reported by a health check.
+        /// If no checks were executed, the value is always <see cref="HealthStatus.Healthy"/>.
+        /// </summary>
+        public HealthStatus Status { get; set; } = HealthStatus.Healthy;
+
+        /// <summary>
+        /// Gets the time the health check service took to execute.
+        /// </summary>
+        public TimeSpan TotalDuration { get; set; }
+
+        /// <summary>
+        /// Creates a JSON data-transfer object from the given <paramref name="report"/>.
+        /// </summary>
+        /// <param name="report">The finalized health report.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="report"/> is <c>null</c>.</exception>
+        public static HealthReportJson FromHealthReport(HealthReport report)
+        {
+            Guard.NotNull(report, nameof(report), "Requires a Microsoft HealthReport instance to convert to a JSON instance without the exception details");
+
+            IDictionary<string, HealthReportEntryJson> entries = 
+                report.Entries.ToDictionary(
+                    item => item.Key, 
+                    item => HealthReportEntryJson.FromHealthReportEntry(item.Value));
+            
+            return new HealthReportJson
+            {
+                Entries = entries,
+                Status = report.Status,
+                TotalDuration = report.TotalDuration
+            };
+        }
+
+        /// <summary>
+        /// Creates a JSON data-transfer object from the given <paramref name="report"/>.
+        /// </summary>
+        /// <param name="report">The finalized health report.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="report"/> is <c>null</c>.</exception>
+        public static HealthReport ToHealthReport(HealthReportJson report)
+        {
+            Guard.NotNull(report, nameof(report), "Requires a Microsoft HealthReport instance to convert to a JSON instance without the exception details");
+
+            IDictionary<string, HealthReportEntry> entries =
+                report.Entries.ToDictionary(
+                    item => item.Key, 
+                    item => HealthReportEntryJson.ToHealthReportEntry(item.Value));
+
+            return new HealthReport(
+                new ReadOnlyDictionary<string, HealthReportEntry>(entries),
+                report.TotalDuration);
+        }
+    }
+}


### PR DESCRIPTION
Adds a custom `HealthReportJson` JSON data-transfer object to the WebAPI project template with the necessary feature documentation.

Relates to https://github.com/arcus-azure/arcus.templates/issues/491