### PR TITLE
feat: use webapi security extensions instead

### DIFF
--- a/src/Arcus.Templates.WebApi/.template.config/template.json
+++ b/src/Arcus.Templates.WebApi/.template.config/template.json
@@ -34,7 +34,7 @@
           ]
         },
         {
-          "condition": "ExcludeOpenApi",
+          "condition": "!(OpenApi)",
           "exclude": [
             "**/ExampleProviders/HealthReportResponseExampleProvider.cs"
           ]

--- a/src/Arcus.Templates.WebApi/.template.config/template.json
+++ b/src/Arcus.Templates.WebApi/.template.config/template.json
@@ -134,9 +134,9 @@
       "defaultValue": "false",
       "description": "Exclude the capability to correlate between HTTP requests/responses from the API project"
     },
-    "ExcludeCorrelation": {
+    "Correlation": {
       "type": "computed",
-      "value": "exclude-correlation"
+      "value": "!(exclude-correlation)"
     },
     "exclude-openApi": {
       "type": "parameter",
@@ -144,9 +144,9 @@
       "defaultValue": "false",
       "description": "Exclude the OpenApi docs, UI generation from XML docs from the web API project"
     },
-    "ExcludeOpenApi": {
+    "OpenApi": {
       "type": "computed",
-      "value": "exclude-openApi"
+      "value": "!(exclude-openApi)"
     },
     "logging": {
       "type": "parameter",

--- a/src/Arcus.Templates.WebApi/Arcus.Templates.WebApi.csproj
+++ b/src/Arcus.Templates.WebApi/Arcus.Templates.WebApi.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <GenerateDocumentationFile Condition="'$(ExcludeOpenApi)' == 'false'">true</GenerateDocumentationFile>
-    <DocumentationFile Condition="'$(ExcludeOpenApi)' == 'false'">Arcus.Templates.WebApi.Open-Api.xml</DocumentationFile>
+    <GenerateDocumentationFile Condition="'$(OpenApi)' == 'true'">true</GenerateDocumentationFile>
+    <DocumentationFile Condition="'$(OpenApi)' == 'true'">Arcus.Templates.WebApi.Open-Api.xml</DocumentationFile>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <!--#if (AuthoringMode)-->
     <Authors>Arcus</Authors>

--- a/src/Arcus.Templates.WebApi/Arcus.Templates.WebApi.csproj
+++ b/src/Arcus.Templates.WebApi/Arcus.Templates.WebApi.csproj
@@ -39,13 +39,14 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <DefineConstants>$(DefineConstants);SharedAccessKeyAuth;CertificateAuth;Auth;Serilog;OpenApi;Correlation</DefineConstants>
+    <DefineConstants>$(DefineConstants);SharedAccessKeyAuth;CertificateAuth;Auth;Serilog;Console;OpenApi;Correlation</DefineConstants>
     <SharedAccessKeyAuth>true</SharedAccessKeyAuth>
     <CertificateAuth>true</CertificateAuth>
     <JwtAuth>false</JwtAuth>
     <Auth>true</Auth>
     <Correlation>true</Correlation>
     <Serilog>true</Serilog>
+    <Console>true</Console>
     <OpenApi>true</OpenApi>
   </PropertyGroup>
 

--- a/src/Arcus.Templates.WebApi/Arcus.Templates.WebApi.csproj
+++ b/src/Arcus.Templates.WebApi/Arcus.Templates.WebApi.csproj
@@ -39,9 +39,14 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <DefineConstants>$(DefineConstants);</DefineConstants>
-    <ExcludeCorrelation>false</ExcludeCorrelation>
-    <ExcludeOpenApi>false</ExcludeOpenApi>
+    <DefineConstants>$(DefineConstants);SharedAccessKeyAuth;CertificateAuth;Auth;Serilog;OpenApi;Correlation</DefineConstants>
+    <SharedAccessKeyAuth>true</SharedAccessKeyAuth>
+    <CertificateAuth>true</CertificateAuth>
+    <JwtAuth>false</JwtAuth>
+    <Auth>true</Auth>
+    <Correlation>true</Correlation>
+    <Serilog>true</Serilog>
+    <OpenApi>true</OpenApi>
   </PropertyGroup>
 
   <ItemGroup>
@@ -69,8 +74,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.5" Condition="'$(JwtAuth)' == 'true'" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.15.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" Condition="'$(Serilog)' == 'true'" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" Condition="'$(ExcludeOpenApi)' == 'false'" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="7.0.3" Condition="'$(ExcludeOpenApi)' == 'false' and '$(ExcludeCorrelation)' == 'false'" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.1" Condition="'$(OpenApi)' == 'true'" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="7.0.3" Condition="'$(OpenApi)' == 'true' and '$(Correlation)' == 'true'" />
   </ItemGroup>
 
 </Project>

--- a/src/Arcus.Templates.WebApi/Controllers/HealthController.cs
+++ b/src/Arcus.Templates.WebApi/Controllers/HealthController.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using GuardNet;
-#if (ExcludeOpenApi == false)
+#if OpenApi
 using Arcus.Templates.WebApi.ExampleProviders;
 using Swashbuckle.AspNetCore.Filters;
 #endif
@@ -41,8 +41,8 @@ namespace Arcus.Templates.WebApi.Controllers
         [RequestTracking(500, 599)]
         [ProducesResponseType(typeof(HealthReport), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(HealthReport), StatusCodes.Status503ServiceUnavailable)]
-#if (ExcludeOpenApi == false)
-#if (ExcludeCorrelation == false)
+#if OpenApi
+#if Correlation
         [SwaggerResponseHeader(200, "RequestId", "string", "The header that has a request ID that uniquely identifies this operation call")]
         [SwaggerResponseHeader(200, "X-Transaction-Id", "string", "The header that has the transaction ID is used to correlate multiple operation calls.")]
 #endif

--- a/src/Arcus.Templates.WebApi/Controllers/HealthController.cs
+++ b/src/Arcus.Templates.WebApi/Controllers/HealthController.cs
@@ -40,17 +40,10 @@ namespace Arcus.Templates.WebApi.Controllers
         /// <response code="503">API is unhealthy or in degraded state</response>
         [HttpGet(Name = "Health_Get")]
         [RequestTracking(500, 599)]
-<<<<<<< HEAD
-        [ProducesResponseType(typeof(HealthReport), StatusCodes.Status200OK)]
-        [ProducesResponseType(typeof(HealthReport), StatusCodes.Status503ServiceUnavailable)]
-#if OpenApi
-#if Correlation
-=======
         [ProducesResponseType(typeof(ApiHealthReport), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(ApiHealthReport), StatusCodes.Status503ServiceUnavailable)]
-#if (ExcludeOpenApi == false)
-#if (ExcludeCorrelation == false)
->>>>>>> master
+#if OpenApi
+#if Correlation
         [SwaggerResponseHeader(200, "RequestId", "string", "The header that has a request ID that uniquely identifies this operation call")]
         [SwaggerResponseHeader(200, "X-Transaction-Id", "string", "The header that has the transaction ID is used to correlate multiple operation calls.")]
 #endif

--- a/src/Arcus.Templates.WebApi/Program.cs
+++ b/src/Arcus.Templates.WebApi/Program.cs
@@ -191,7 +191,7 @@ namespace Arcus.Templates.WebApi
 #if Correlation
             builder.Services.AddHttpCorrelation((HttpCorrelationInfoOptions options) => { });
 #endif
-#if (ExcludeOpenApi == false)
+#if OpenApi
             
             ConfigureOpenApi(builder);
 #endif

--- a/src/Arcus.Templates.WebApi/Program.cs
+++ b/src/Arcus.Templates.WebApi/Program.cs
@@ -157,10 +157,10 @@ namespace Arcus.Templates.WebApi
 
 #if SharedAccessKeyAuth
                 #warning Please provide a valid request header name and secret name to the shared access filter
-                options.Filters.Add(new SharedAccessKeyAuthenticationFilter(headerName: SharedAccessKeyHeaderName, queryParameterName: null, secretName: "<your-secret-name>"));
+                options.Filters.AddSharedAccessKeyAuthentication(headerName: SharedAccessKeyHeaderName, queryParameterName: null, secretName: "<your-secret-name>");
 #endif
 #if CertificateAuth
-                options.Filters.Add(new CertificateAuthenticationFilter());
+                options.Filters.AddCertificateAuthentication();
 #endif
 #if JwtAuth
                 AuthorizationPolicy policy = 

--- a/src/Arcus.Templates.WebApi/Program.cs
+++ b/src/Arcus.Templates.WebApi/Program.cs
@@ -14,6 +14,9 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+#if Console
+using Microsoft.Extensions.Logging; 
+#endif
 #if Serilog
 using Serilog;
 using Serilog.Configuration;

--- a/src/Arcus.Templates.WebApi/Program.cs
+++ b/src/Arcus.Templates.WebApi/Program.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Security.AccessControl;
 using System.Text.Json.Serialization;
 using Arcus.Security.Core.Caching.Configuration;
-#if (ExcludeCorrelation == false)
+#if Correlation
 using Arcus.WebApi.Logging.Core.Correlation;
 #endif
 using Microsoft.AspNetCore.Builder;
@@ -14,34 +14,25 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 #if Serilog
 using Serilog;
 using Serilog.Configuration;
 using Serilog.Events;
-using Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights;
 #endif
-#if (ExcludeOpenApi == false)
+#if OpenApi
 using Microsoft.OpenApi.Models;
 using Arcus.Templates.WebApi.ExampleProviders;
 using Swashbuckle.AspNetCore.Filters;
 #endif
-#if SharedAccessKeyAuth
-using Arcus.Security.Core.Caching;
-using Arcus.WebApi.Security.Authentication.SharedAccessKey;
+#if Auth
+using Microsoft.AspNetCore.Mvc.Filters;
 #endif
 #if CertificateAuth
-using System.Security.Cryptography.X509Certificates;
-using System.Threading.Tasks;
 using Arcus.WebApi.Security.Authentication.Certificates;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Primitives;
 #endif
 #if JwtAuth
 using System.Text;
 using Arcus.Security.Core;
-using Arcus.Security.Core.Caching;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.Authorization;
@@ -157,7 +148,7 @@ namespace Arcus.Templates.WebApi
 
 #if SharedAccessKeyAuth
                 #warning Please provide a valid request header name and secret name to the shared access filter
-                options.Filters.AddSharedAccessKeyAuthentication(headerName: SharedAccessKeyHeaderName, queryParameterName: null, secretName: "<your-secret-name>");
+                options.Filters.AddSharedAccessKeyAuthenticationOnHeader(SharedAccessKeyHeaderName, "<your-secret-name>");
 #endif
 #if CertificateAuth
                 options.Filters.AddCertificateAuthentication();
@@ -173,7 +164,7 @@ namespace Arcus.Templates.WebApi
 #endif
             });
 #if JwtAuth
-#error Use previously registered secret provider, for example Azure Key Vault: https://security.arcus-azure.net/features/secrets/consume-from-key-vault
+            #error Use previously registered secret provider, for example Azure Key Vault: https://security.arcus-azure.net/features/secrets/consume-from-key-vault
             builder.Services.AddAuthentication(auth =>
             {
                 auth.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
@@ -197,7 +188,7 @@ namespace Arcus.Templates.WebApi
             });
 #endif
             builder.Services.AddHealthChecks();
-#if (ExcludeCorrelation == false)
+#if Correlation
             builder.Services.AddHttpCorrelation((HttpCorrelationInfoOptions options) => { });
 #endif
 #if (ExcludeOpenApi == false)
@@ -205,12 +196,11 @@ namespace Arcus.Templates.WebApi
             ConfigureOpenApi(builder);
 #endif
         }
-#if (ExcludeOpenApi == false)
+#if OpenApi
         
         private static void ConfigureOpenApi(WebApplicationBuilder builder)
         {
-#warning Be careful of exposing sensitive information with the OpenAPI document, only expose what's necessary and hide everything else.
-            
+            #warning Be careful of exposing sensitive information with the OpenAPI document, only expose what's necessary and hide everything else.
             var openApiInformation = new OpenApiInfo
             {
                 Title = "Arcus.Templates.WebApi",
@@ -223,7 +213,7 @@ namespace Arcus.Templates.WebApi
                 swaggerGenerationOptions.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, "Arcus.Templates.WebApi.Open-Api.xml"));
 
                 swaggerGenerationOptions.ExampleFilters();
-#if (ExcludeCorrelation == false)
+#if Correlation
                 swaggerGenerationOptions.OperationFilter<AddHeaderOperationFilter>("X-Transaction-Id", "Transaction ID is used to correlate multiple operation calls. A new transaction ID will be generated if not specified.", false);
                 swaggerGenerationOptions.OperationFilter<AddResponseHeadersFilter>();
 #endif
@@ -318,7 +308,7 @@ namespace Arcus.Templates.WebApi
                 stores.AddAzureKeyVaultWithManagedIdentity("https://your-keyvault.vault.azure.net/", CacheConfiguration.Default);
             });
 #if Serilog
-            builder.Host.UseSerilog((context, serviceProvider, config) => CreateLoggerConfiguration(context, serviceProvider, config));
+            builder.Host.UseSerilog(ConfigureLoggerConfiguration);
 #endif
 #if Console
             builder.Host.ConfigureLogging(logging => logging.AddConsole());
@@ -327,7 +317,7 @@ namespace Arcus.Templates.WebApi
 
 #if Serilog
         
-        private static LoggerConfiguration CreateLoggerConfiguration(
+        private static void ConfigureLoggerConfiguration(
             HostBuilderContext context, 
             IServiceProvider serviceProvider, 
             LoggerConfiguration config)
@@ -337,7 +327,7 @@ namespace Arcus.Templates.WebApi
                   .Enrich.FromLogContext()
                   .Enrich.WithVersion()
                   .Enrich.WithComponentName("API")
-#if (ExcludeCorrelation == false)
+#if Correlation
                    .Enrich.WithHttpCorrelationInfo(serviceProvider)
 #endif
                    .WriteTo.Console();
@@ -347,14 +337,12 @@ namespace Arcus.Templates.WebApi
             {
                 config.WriteTo.AzureApplicationInsights(instrumentationKey);
             }
-
-            return config;
         }
         
 #endif
         private static void ConfigureApp(IApplicationBuilder app)
         {
-#if (ExcludeCorrelation == false)
+#if Correlation
             app.UseHttpCorrelation();
 #endif
             app.UseRouting();
@@ -369,7 +357,7 @@ namespace Arcus.Templates.WebApi
             #warning Please configure application with authentication mechanism: https://webapi.arcus-azure.net/features/security/auth/shared-access-key
 #endif
 
-#if (ExcludeOpenApi == false)
+#if OpenApi
             app.UseSwagger(swaggerOptions =>
             {
                 swaggerOptions.RouteTemplate = "api/{documentName}/docs.json";


### PR DESCRIPTION
Use the user-friendly security authentication extensions instead of using the security filters themselves.

Closes #496