### PR TITLE
chore: add direct observability references

### DIFF
--- a/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/Arcus.Templates.AzureFunctions.Databricks.JobMetrics.csproj
+++ b/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/Arcus.Templates.AzureFunctions.Databricks.JobMetrics.csproj
@@ -57,7 +57,9 @@
 
   <ItemGroup>
     <PackageReference Include="Arcus.BackgroundJobs.Databricks" Version="0.4.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.4.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.AzureFunctions" Version="2.4.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Filters" Version="2.4.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.Applicationinsights" Version="2.4.0" />
     <PackageReference Include="Arcus.Security.AzureFunctions" Version="1.7.0" />
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.7.0" />

--- a/src/Arcus.Templates.AzureFunctions.Http/Arcus.Templates.AzureFunctions.Http.csproj
+++ b/src/Arcus.Templates.AzureFunctions.Http/Arcus.Templates.AzureFunctions.Http.csproj
@@ -57,8 +57,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Arcus.Observability.Correlation" Version="2.4.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.AspNetCore" Version="2.4.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.AzureFunctions" Version="2.4.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.4.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Filters" Version="2.4.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.Applicationinsights" Version="2.4.0" />
     <PackageReference Include="Arcus.Security.AzureFunctions" Version="1.7.0" />
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.7.0" />

--- a/src/Arcus.Templates.AzureFunctions.ServiceBus.Queue/Arcus.Templates.AzureFunctions.ServiceBus.Queue.csproj
+++ b/src/Arcus.Templates.AzureFunctions.ServiceBus.Queue/Arcus.Templates.AzureFunctions.ServiceBus.Queue.csproj
@@ -47,6 +47,10 @@
   <ItemGroup>
     <PackageReference Include="Arcus.Messaging.Abstractions.ServiceBus" Version="1.2.0" />
     <PackageReference Include="Arcus.Messaging.AzureFunctions.ServiceBus" Version="1.2.0" />
+    <PackageReference Include="Arcus.Observability.Correlation" Version="2.4.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.AzureFunctions" Version="2.4.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.4.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Filters" Version="2.4.0" Condition="'$(Serilog)' == 'true'" />
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="2.4.0" Condition="'$(Serilog)' == 'true'" />
     <PackageReference Include="Arcus.Security.AzureFunctions" Version="1.7.0" />
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.7.0" />

--- a/src/Arcus.Templates.AzureFunctions.ServiceBus.Topic/Arcus.Templates.AzureFunctions.ServiceBus.Topic.csproj
+++ b/src/Arcus.Templates.AzureFunctions.ServiceBus.Topic/Arcus.Templates.AzureFunctions.ServiceBus.Topic.csproj
@@ -46,6 +46,10 @@
   <ItemGroup>
     <PackageReference Include="Arcus.Messaging.Abstractions.ServiceBus" Version="1.2.0" />
     <PackageReference Include="Arcus.Messaging.AzureFunctions.ServiceBus" Version="1.2.0" />
+    <PackageReference Include="Arcus.Observability.Correlation" Version="2.4.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.AzureFunctions" Version="2.4.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.4.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Filters" Version="2.4.0" Condition="'$(Serilog)' == 'true'" />
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="2.4.0" Condition="'$(Serilog)' == 'true'" />
     <PackageReference Include="Arcus.Security.AzureFunctions" Version="1.7.0" />
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.7.0" />

--- a/src/Arcus.Templates.ServiceBus.Queue/Arcus.Templates.ServiceBus.Queue.csproj
+++ b/src/Arcus.Templates.ServiceBus.Queue/Arcus.Templates.ServiceBus.Queue.csproj
@@ -50,7 +50,9 @@
   <ItemGroup>
     <PackageReference Include="Arcus.Messaging.Health" Version="1.2.0" />
     <PackageReference Include="Arcus.Messaging.Pumps.ServiceBus" Version="1.2.0" />
+    <PackageReference Include="Arcus.Observability.Correlation" Version="2.4.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.4.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Filters" Version="2.4.0" Condition="'$(Serilog)' == 'true'" />
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="2.4.0" Condition="'$(Serilog)' == 'true'" />
     <PackageReference Include="Arcus.Security.Core" Version="1.7.0" />
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.7.0" />

--- a/src/Arcus.Templates.ServiceBus.Topic/Arcus.Templates.ServiceBus.Topic.csproj
+++ b/src/Arcus.Templates.ServiceBus.Topic/Arcus.Templates.ServiceBus.Topic.csproj
@@ -50,7 +50,9 @@
   <ItemGroup>
     <PackageReference Include="Arcus.Messaging.Health" Version="1.2.0" />
     <PackageReference Include="Arcus.Messaging.Pumps.ServiceBus" Version="1.2.0" />
+    <PackageReference Include="Arcus.Observability.Correlation" Version="2.4.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.4.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Filters" Version="2.4.0" Condition="'$(Serilog)' == 'true'" />
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="2.4.0" Condition="'$(Serilog)' == 'true'" />
     <PackageReference Include="Arcus.Security.Core" Version="1.7.0" />
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.7.0" />

--- a/src/Arcus.Templates.WebApi/Arcus.Templates.WebApi.csproj
+++ b/src/Arcus.Templates.WebApi/Arcus.Templates.WebApi.csproj
@@ -64,8 +64,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Arcus.Observability.Correlation" Version="2.4.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.AspNetCore" Version="2.4.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.4.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Filters" Version="2.4.0" Condition="'$(Serilog)' == 'true'" />
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="2.4.0" Condition="'$(Serilog)' == 'true'" />
     <PackageReference Include="Arcus.Security.Core" Version="1.7.0" />
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.7.0" />


### PR DESCRIPTION
Adds direct observability references to the project templates so that updates in observability results in quicker templates releases.

Closes #596