### PR TITLE
feat: Add the RemoveMicrosoftApplicationInsightsLoggerProvider extension to all Serilog infrastructure code

### DIFF
--- a/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/Arcus.Templates.AzureFunctions.Databricks.JobMetrics.csproj
+++ b/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/Arcus.Templates.AzureFunctions.Databricks.JobMetrics.csproj
@@ -25,7 +25,7 @@
     <ContentTargetFolders>content</ContentTargetFolders>
     <EnableDefaultContentItems>false</EnableDefaultContentItems>
     <DockerComposeProjectPath>..\Arcus.Templates.Orchestrator.dcproj</DockerComposeProjectPath>
-	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU5048;NU5125;NU5119;NU5128</NoWarn>
     <!--#endif-->
   </PropertyGroup>

--- a/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/Arcus.Templates.AzureFunctions.Databricks.JobMetrics.csproj
+++ b/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/Arcus.Templates.AzureFunctions.Databricks.JobMetrics.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
@@ -25,7 +25,6 @@
     <ContentTargetFolders>content</ContentTargetFolders>
     <EnableDefaultContentItems>false</EnableDefaultContentItems>
     <DockerComposeProjectPath>..\Arcus.Templates.Orchestrator.dcproj</DockerComposeProjectPath>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU5048;NU5125;NU5119;NU5128</NoWarn>
     <!--#endif-->
   </PropertyGroup>
@@ -58,7 +57,7 @@
   <ItemGroup>
     <PackageReference Include="Arcus.BackgroundJobs.Databricks" Version="0.4.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.4.0" />
-    <PackageReference Include="Arcus.Observability.Telemetry.AzureFunctions" Version="2.4.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.AzureFunctions" Version="2.5.0-preview-1" />
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Filters" Version="2.4.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.Applicationinsights" Version="2.4.0" />
     <PackageReference Include="Arcus.Security.AzureFunctions" Version="1.7.0" />

--- a/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/Arcus.Templates.AzureFunctions.Databricks.JobMetrics.csproj
+++ b/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/Arcus.Templates.AzureFunctions.Databricks.JobMetrics.csproj
@@ -57,7 +57,7 @@
   <ItemGroup>
     <PackageReference Include="Arcus.BackgroundJobs.Databricks" Version="0.4.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.4.0" />
-    <PackageReference Include="Arcus.Observability.Telemetry.AzureFunctions" Version="2.5.0-preview-1" />
+    <PackageReference Include="Arcus.Observability.Telemetry.AzureFunctions" Version="2.5.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Filters" Version="2.4.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.Applicationinsights" Version="2.4.0" />
     <PackageReference Include="Arcus.Security.AzureFunctions" Version="1.7.0" />

--- a/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/Arcus.Templates.AzureFunctions.Databricks.JobMetrics.csproj
+++ b/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/Arcus.Templates.AzureFunctions.Databricks.JobMetrics.csproj
@@ -25,6 +25,7 @@
     <ContentTargetFolders>content</ContentTargetFolders>
     <EnableDefaultContentItems>false</EnableDefaultContentItems>
     <DockerComposeProjectPath>..\Arcus.Templates.Orchestrator.dcproj</DockerComposeProjectPath>
+	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU5048;NU5125;NU5119;NU5128</NoWarn>
     <!--#endif-->
   </PropertyGroup>

--- a/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/Startup.cs
+++ b/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/Startup.cs
@@ -43,7 +43,7 @@ namespace Arcus.Templates.AzureFunctions.Databricks.JobMetrics
             builder.Services.AddLogging(logging =>
             {
                 logging.RemoveMicrosoftApplicationInsightsLoggerProvider()
-                    .AddSerilog(logConfig.CreateLogger(), dispose: true);
+                       .AddSerilog(logConfig.CreateLogger(), dispose: true);
             });
             
         }

--- a/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/Startup.cs
+++ b/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/Startup.cs
@@ -4,6 +4,7 @@ using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Serilog;
 using Serilog.Configuration;
 using Serilog.Events;
@@ -41,8 +42,10 @@ namespace Arcus.Templates.AzureFunctions.Databricks.JobMetrics
             LoggerConfiguration logConfig = CreateLoggerConfiguration(builder);
             builder.Services.AddLogging(logging =>
             {
-                logging.AddSerilog(logConfig.CreateLogger(), dispose: true);
+                logging.RemoveMicrosoftApplicationInsightsLoggerProvider()
+                    .AddSerilog(logConfig.CreateLogger(), dispose: true);
             });
+            
         }
         
         private static LoggerConfiguration CreateLoggerConfiguration(IFunctionsHostBuilder builder)

--- a/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/Startup.cs
+++ b/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/Startup.cs
@@ -45,7 +45,6 @@ namespace Arcus.Templates.AzureFunctions.Databricks.JobMetrics
                 logging.RemoveMicrosoftApplicationInsightsLoggerProvider()
                        .AddSerilog(logConfig.CreateLogger(), dispose: true);
             });
-            
         }
         
         private static LoggerConfiguration CreateLoggerConfiguration(IFunctionsHostBuilder builder)

--- a/src/Arcus.Templates.AzureFunctions.Http/Arcus.Templates.AzureFunctions.Http.csproj
+++ b/src/Arcus.Templates.AzureFunctions.Http/Arcus.Templates.AzureFunctions.Http.csproj
@@ -58,7 +58,7 @@
   <ItemGroup>
     <PackageReference Include="Arcus.Observability.Correlation" Version="2.4.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.AspNetCore" Version="2.4.0" />
-    <PackageReference Include="Arcus.Observability.Telemetry.AzureFunctions" Version="2.5.0-preview-1" />
+    <PackageReference Include="Arcus.Observability.Telemetry.AzureFunctions" Version="2.5.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.4.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Filters" Version="2.4.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.Applicationinsights" Version="2.4.0" />

--- a/src/Arcus.Templates.AzureFunctions.Http/Arcus.Templates.AzureFunctions.Http.csproj
+++ b/src/Arcus.Templates.AzureFunctions.Http/Arcus.Templates.AzureFunctions.Http.csproj
@@ -25,7 +25,6 @@
     <ContentTargetFolders>content</ContentTargetFolders>
     <EnableDefaultContentItems>false</EnableDefaultContentItems>
     <DockerComposeProjectPath>..\Arcus.Templates.Orchestrator.dcproj</DockerComposeProjectPath>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU5048;NU5125;NU5119;NU5128;CS0618</NoWarn>
     <!--#endif-->
   </PropertyGroup>
@@ -59,7 +58,7 @@
   <ItemGroup>
     <PackageReference Include="Arcus.Observability.Correlation" Version="2.4.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.AspNetCore" Version="2.4.0" />
-    <PackageReference Include="Arcus.Observability.Telemetry.AzureFunctions" Version="2.4.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.AzureFunctions" Version="2.5.0-preview-1" />
     <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.4.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Filters" Version="2.4.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.Applicationinsights" Version="2.4.0" />

--- a/src/Arcus.Templates.AzureFunctions.Http/Arcus.Templates.AzureFunctions.Http.csproj
+++ b/src/Arcus.Templates.AzureFunctions.Http/Arcus.Templates.AzureFunctions.Http.csproj
@@ -25,7 +25,7 @@
     <ContentTargetFolders>content</ContentTargetFolders>
     <EnableDefaultContentItems>false</EnableDefaultContentItems>
     <DockerComposeProjectPath>..\Arcus.Templates.Orchestrator.dcproj</DockerComposeProjectPath>
-	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU5048;NU5125;NU5119;NU5128;CS0618</NoWarn>
     <!--#endif-->
   </PropertyGroup>

--- a/src/Arcus.Templates.AzureFunctions.Http/Arcus.Templates.AzureFunctions.Http.csproj
+++ b/src/Arcus.Templates.AzureFunctions.Http/Arcus.Templates.AzureFunctions.Http.csproj
@@ -25,6 +25,7 @@
     <ContentTargetFolders>content</ContentTargetFolders>
     <EnableDefaultContentItems>false</EnableDefaultContentItems>
     <DockerComposeProjectPath>..\Arcus.Templates.Orchestrator.dcproj</DockerComposeProjectPath>
+	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>NU5048;NU5125;NU5119;NU5128;CS0618</NoWarn>
     <!--#endif-->
   </PropertyGroup>

--- a/src/Arcus.Templates.AzureFunctions.Http/Startup.cs
+++ b/src/Arcus.Templates.AzureFunctions.Http/Startup.cs
@@ -53,7 +53,7 @@ namespace Arcus.Templates.AzureFunctions.Http
             builder.Services.AddLogging(logging =>
             {
                 logging.RemoveMicrosoftApplicationInsightsLoggerProvider()
-                    .AddSerilog(logConfig.CreateLogger(), dispose: true);
+                       .AddSerilog(logConfig.CreateLogger(), dispose: true);
             });
         }
 

--- a/src/Arcus.Templates.AzureFunctions.Http/Startup.cs
+++ b/src/Arcus.Templates.AzureFunctions.Http/Startup.cs
@@ -5,6 +5,7 @@ using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Serilog;
 using Serilog.Configuration;
 using Serilog.Events;
@@ -51,7 +52,8 @@ namespace Arcus.Templates.AzureFunctions.Http
             LoggerConfiguration logConfig = CreateLoggerConfiguration(builder);
             builder.Services.AddLogging(logging =>
             {
-                logging.AddSerilog(logConfig.CreateLogger(), dispose: true);
+                logging.RemoveMicrosoftApplicationInsightsLoggerProvider()
+                    .AddSerilog(logConfig.CreateLogger(), dispose: true);
             });
         }
 

--- a/src/Arcus.Templates.AzureFunctions.ServiceBus.Queue/Arcus.Templates.AzureFunctions.ServiceBus.Queue.csproj
+++ b/src/Arcus.Templates.AzureFunctions.ServiceBus.Queue/Arcus.Templates.AzureFunctions.ServiceBus.Queue.csproj
@@ -48,7 +48,7 @@
     <PackageReference Include="Arcus.Messaging.Abstractions.ServiceBus" Version="1.2.0" />
     <PackageReference Include="Arcus.Messaging.AzureFunctions.ServiceBus" Version="1.2.0" />
     <PackageReference Include="Arcus.Observability.Correlation" Version="2.4.0" />
-    <PackageReference Include="Arcus.Observability.Telemetry.AzureFunctions" Version="2.5.0-preview-1" />
+    <PackageReference Include="Arcus.Observability.Telemetry.AzureFunctions" Version="2.5.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.4.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Filters" Version="2.4.0" Condition="'$(Serilog)' == 'true'" />
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="2.4.0" Condition="'$(Serilog)' == 'true'" />

--- a/src/Arcus.Templates.AzureFunctions.ServiceBus.Queue/Arcus.Templates.AzureFunctions.ServiceBus.Queue.csproj
+++ b/src/Arcus.Templates.AzureFunctions.ServiceBus.Queue/Arcus.Templates.AzureFunctions.ServiceBus.Queue.csproj
@@ -48,7 +48,7 @@
     <PackageReference Include="Arcus.Messaging.Abstractions.ServiceBus" Version="1.2.0" />
     <PackageReference Include="Arcus.Messaging.AzureFunctions.ServiceBus" Version="1.2.0" />
     <PackageReference Include="Arcus.Observability.Correlation" Version="2.4.0" />
-    <PackageReference Include="Arcus.Observability.Telemetry.AzureFunctions" Version="2.4.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.AzureFunctions" Version="2.5.0-preview-1" />
     <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.4.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Filters" Version="2.4.0" Condition="'$(Serilog)' == 'true'" />
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="2.4.0" Condition="'$(Serilog)' == 'true'" />

--- a/src/Arcus.Templates.AzureFunctions.ServiceBus.Queue/Startup.cs
+++ b/src/Arcus.Templates.AzureFunctions.ServiceBus.Queue/Startup.cs
@@ -5,6 +5,7 @@ using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 #if Serilog
 using Serilog;
 using Serilog.Configuration;
@@ -46,7 +47,8 @@ namespace Arcus.Templates.AzureFunctions.ServiceBus.Queue
             LoggerConfiguration logConfig = CreateLoggerConfiguration(builder);
             builder.Services.AddLogging(logging =>
             {
-                logging.AddSerilog(logConfig.CreateLogger(), dispose: true);
+                logging.RemoveMicrosoftApplicationInsightsLoggerProvider()
+                    .AddSerilog(logConfig.CreateLogger(), dispose: true);
             }); 
 #endif
         }

--- a/src/Arcus.Templates.AzureFunctions.ServiceBus.Queue/Startup.cs
+++ b/src/Arcus.Templates.AzureFunctions.ServiceBus.Queue/Startup.cs
@@ -48,7 +48,7 @@ namespace Arcus.Templates.AzureFunctions.ServiceBus.Queue
             builder.Services.AddLogging(logging =>
             {
                 logging.RemoveMicrosoftApplicationInsightsLoggerProvider()
-                    .AddSerilog(logConfig.CreateLogger(), dispose: true);
+                       .AddSerilog(logConfig.CreateLogger(), dispose: true);
             }); 
 #endif
         }

--- a/src/Arcus.Templates.AzureFunctions.ServiceBus.Topic/Arcus.Templates.AzureFunctions.ServiceBus.Topic.csproj
+++ b/src/Arcus.Templates.AzureFunctions.ServiceBus.Topic/Arcus.Templates.AzureFunctions.ServiceBus.Topic.csproj
@@ -47,7 +47,7 @@
     <PackageReference Include="Arcus.Messaging.Abstractions.ServiceBus" Version="1.2.0" />
     <PackageReference Include="Arcus.Messaging.AzureFunctions.ServiceBus" Version="1.2.0" />
     <PackageReference Include="Arcus.Observability.Correlation" Version="2.4.0" />
-    <PackageReference Include="Arcus.Observability.Telemetry.AzureFunctions" Version="2.4.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.AzureFunctions" Version="2.5.0-preview-1" />
     <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.4.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Filters" Version="2.4.0" Condition="'$(Serilog)' == 'true'" />
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="2.4.0" Condition="'$(Serilog)' == 'true'" />

--- a/src/Arcus.Templates.AzureFunctions.ServiceBus.Topic/Arcus.Templates.AzureFunctions.ServiceBus.Topic.csproj
+++ b/src/Arcus.Templates.AzureFunctions.ServiceBus.Topic/Arcus.Templates.AzureFunctions.ServiceBus.Topic.csproj
@@ -47,7 +47,7 @@
     <PackageReference Include="Arcus.Messaging.Abstractions.ServiceBus" Version="1.2.0" />
     <PackageReference Include="Arcus.Messaging.AzureFunctions.ServiceBus" Version="1.2.0" />
     <PackageReference Include="Arcus.Observability.Correlation" Version="2.4.0" />
-    <PackageReference Include="Arcus.Observability.Telemetry.AzureFunctions" Version="2.5.0-preview-1" />
+    <PackageReference Include="Arcus.Observability.Telemetry.AzureFunctions" Version="2.5.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.4.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Filters" Version="2.4.0" Condition="'$(Serilog)' == 'true'" />
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="2.4.0" Condition="'$(Serilog)' == 'true'" />

--- a/src/Arcus.Templates.AzureFunctions.ServiceBus.Topic/Startup.cs
+++ b/src/Arcus.Templates.AzureFunctions.ServiceBus.Topic/Startup.cs
@@ -5,6 +5,7 @@ using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 #if Serilog
 using Serilog;
 using Serilog.Configuration;
@@ -46,7 +47,8 @@ namespace Arcus.Templates.AzureFunctions.ServiceBus.Topic
             LoggerConfiguration logConfig = CreateLoggerConfiguration(builder);
             builder.Services.AddLogging(logging =>
             {
-                logging.AddSerilog(logConfig.CreateLogger(), dispose: true);
+                logging.RemoveMicrosoftApplicationInsightsLoggerProvider()
+                    .AddSerilog(logConfig.CreateLogger(), dispose: true);
             }); 
 #endif
         }

--- a/src/Arcus.Templates.AzureFunctions.ServiceBus.Topic/Startup.cs
+++ b/src/Arcus.Templates.AzureFunctions.ServiceBus.Topic/Startup.cs
@@ -48,7 +48,7 @@ namespace Arcus.Templates.AzureFunctions.ServiceBus.Topic
             builder.Services.AddLogging(logging =>
             {
                 logging.RemoveMicrosoftApplicationInsightsLoggerProvider()
-                    .AddSerilog(logConfig.CreateLogger(), dispose: true);
+                       .AddSerilog(logConfig.CreateLogger(), dispose: true);
             }); 
 #endif
         }


### PR DESCRIPTION
Add the RemoveMicrosoftApplicationInsightsLoggerProvider extension to all Serilog infrastructure code.
Closes #604 

Replaces: #607 