### PR TITLE
bug: exclude openapi fully

### DIFF
--- a/src/Arcus.Templates.AzureFunctions.Http/.template.config/template.json
+++ b/src/Arcus.Templates.AzureFunctions.Http/.template.config/template.json
@@ -34,6 +34,13 @@
           "exclude": [
             "HealthFunction.cs"
           ]
+        },
+        {
+          "condition": "!(OpenApi)",
+          "exclude": [
+            "HttpCorrelationOpenApiResponseHeaders.cs",
+            "OpenApiConfigurationOptions.cs"
+          ]
         }
       ]
     }
@@ -86,9 +93,9 @@
       "defaultValue": "false",
       "description": "Exclude the OpenApi docs, UI generation from XML docs from the Azure Functions project"
     },
-    "ExcludeOpenApi": {
+    "OpenApi": {
       "type": "computed",
-      "value": "exclude-openApi"
+      "value": "!(exclude-openApi)"
     }
   },
   "postActions": [

--- a/src/Arcus.Templates.AzureFunctions.Http/Arcus.Templates.AzureFunctions.Http.csproj
+++ b/src/Arcus.Templates.AzureFunctions.Http/Arcus.Templates.AzureFunctions.Http.csproj
@@ -36,8 +36,8 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <DefineConstants>$(DefineConstants);</DefineConstants>
-    <ExcludeOpenApi>false</ExcludeOpenApi>
+    <DefineConstants>$(DefineConstants);OpenApi</DefineConstants>
+    <OpenApi>true</OpenApi>
     <DockerFastModeProjectMountDirectory>/home/site/wwwroot</DockerFastModeProjectMountDirectory>
   </PropertyGroup>
 
@@ -68,7 +68,7 @@
     <PackageReference Include="Arcus.WebApi.Logging.AzureFunctions" Version="1.5.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="4.0.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.12" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.OpenApi" Version="1.3.0" Condition="'$(ExcludeOpenApi)' == 'false'" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.OpenApi" Version="1.3.0" Condition="'$(OpenApi)' == 'true'" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.16.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />

--- a/src/Arcus.Templates.AzureFunctions.Http/HealthFunction.cs
+++ b/src/Arcus.Templates.AzureFunctions.Http/HealthFunction.cs
@@ -8,11 +8,15 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
+#if OpenApi
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
-using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums; 
+#endif
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
-using Microsoft.OpenApi.Models;
+#if OpenApi
+using Microsoft.OpenApi.Models; 
+#endif
 
 namespace Arcus.Templates.AzureFunctions.Http
 {
@@ -41,7 +45,7 @@ namespace Arcus.Templates.AzureFunctions.Http
         }
 
         [FunctionName("health")]
-#if (ExcludeOpenApi == false)
+#if OpenApi
         [OpenApiOperation("Health_Get", tags: new[] { "health" }, Summary = "Gets the health report", Description = "Gets the current health report of the running Azure Function", Visibility = OpenApiVisibilityType.Important)]
         [OpenApiSecurity("function_key", SecuritySchemeType.ApiKey, Name = "code", In = OpenApiSecurityLocationType.Header)]
         [OpenApiParameter("X-Transaction-Id", In = ParameterLocation.Header, Type = typeof(string), Required = false, Summary = "The correlation transaction ID", Description = "The correlation transaction ID is used to correlate multiple operation calls")]

--- a/src/Arcus.Templates.AzureFunctions.Http/OrderFunction.cs
+++ b/src/Arcus.Templates.AzureFunctions.Http/OrderFunction.cs
@@ -12,9 +12,11 @@ using Microsoft.Azure.WebJobs.Extensions.Http;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Arcus.Templates.AzureFunctions.Http.Model;
+#if OpenApi
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi.Models; 
+#endif
 
 namespace Arcus.Templates.AzureFunctions.Http
 {
@@ -39,7 +41,7 @@ namespace Arcus.Templates.AzureFunctions.Http
         }
 
         [FunctionName("order")]
-#if (ExcludeOpenApi == false)
+#if OpenApi
         [OpenApiOperation("Order_Get", tags: new[] { "order" }, Summary = "Gets the order", Description = "Gets the order from the request", Visibility = OpenApiVisibilityType.Important)]
         [OpenApiSecurity("function_key", SecuritySchemeType.ApiKey, Name = "code", In = OpenApiSecurityLocationType.Header)]
         [OpenApiRequestBody("application/json", typeof(Order), Description = "The to-be-processed order")]

--- a/src/Arcus.Templates.AzureFunctions.Http/Startup.cs
+++ b/src/Arcus.Templates.AzureFunctions.Http/Startup.cs
@@ -18,12 +18,13 @@ namespace Arcus.Templates.AzureFunctions.Http
         // This method gets called by the runtime. Use this method to configure the app configuration.
         public override void ConfigureAppConfiguration(IFunctionsConfigurationBuilder builder)
         {
+#if OpenApi
 //[#if DEBUG]
             Environment.SetEnvironmentVariable("OpenApi__HideSwaggerUI", "false");
 //[#else]
             Environment.SetEnvironmentVariable("OpenApi__HideSwaggerUI", "true");
 //[#endif]
-            
+#endif
             builder.ConfigurationBuilder.AddEnvironmentVariables();
         }
         

--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/Http/Swagger/SwaggerOpenApiTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/Http/Swagger/SwaggerOpenApiTests.cs
@@ -1,9 +1,17 @@
-﻿using System.Net;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading.Tasks;
+using Arcus.Templates.AzureFunctions.Http.Model;
 using Arcus.Templates.Tests.Integration.Fixture;
+using Bogus;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers;
+using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -15,12 +23,100 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions.Http.Swagger
     {
         private readonly ITestOutputHelper _outputWriter;
 
+        private static readonly Faker BogusGenerator = new Faker();
+
         /// <summary>
         /// Initializes a new instance of the <see cref="SwaggerOpenApiTests" /> class.
         /// </summary>
         public SwaggerOpenApiTests(ITestOutputHelper outputWriter)
         {
             _outputWriter = outputWriter;
+        }
+
+        [Fact]
+        public async Task PostOrder_WithoutOpenApiDocs_StillWorks()
+        {
+            // Arrange
+            var order = new Order
+            {
+                Id = Guid.NewGuid().ToString(),
+                ArticleNumber = BogusGenerator.Random.String(1, 100),
+                Scheduled = BogusGenerator.Date.RecentOffset()
+            };
+
+            var options =
+                new AzureFunctionsHttpProjectOptions().WithExcludeOpenApiDocs();
+
+            using (var project = await AzureFunctionsHttpProject.StartNewAsync(options, _outputWriter))
+            {
+                using (HttpResponseMessage response = await project.Order.PostAsync(order))
+                {
+                    // Assert
+                    string responseContent = await response.Content.ReadAsStringAsync();
+                    Assert.True(HttpStatusCode.OK == response.StatusCode, responseContent);
+                    Assert.NotNull(JsonSerializer.Deserialize<Order>(responseContent));
+                    
+                    IEnumerable<string> responseHeaderNames = response.Headers.Select(header => header.Key).ToArray();
+                    Assert.Contains("X-Transaction-ID", responseHeaderNames);
+                    Assert.Contains("RequestId", responseHeaderNames);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task GetHealth_WithoutOpenApiDocs_StillWorks()
+        {
+            // Arrange
+            var options =
+                new AzureFunctionsHttpProjectOptions()
+                    .WithIncludeHealthChecks()
+                    .WithExcludeOpenApiDocs();
+
+            using (var project = await AzureFunctionsHttpProject.StartNewAsync(options, _outputWriter))
+            {
+                // Act
+                using (HttpResponseMessage response = await project.Health.GetAsync())
+                {
+                    // Assert
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                    Assert.NotEmpty(response.Headers.GetValues("RequestId"));
+                    Assert.NotEmpty(response.Headers.GetValues("X-Transaction-Id"));
+                    
+                    string healthReportJson = await response.Content.ReadAsStringAsync();
+                    var healthReport = JObject.Parse(healthReportJson);
+                    Assert.Equal(HealthStatus.Healthy.ToString(), healthReport["status"]);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task Create_WithoutOpenApiDocs_RemovesOpenApiFiles()
+        {
+            // Arrange
+            var options =
+                new AzureFunctionsHttpProjectOptions().WithExcludeOpenApiDocs();
+
+            using (var project = await AzureFunctionsHttpProject.StartNewAsync(options, _outputWriter))
+            {
+               // Assert
+               Assert.False(project.ContainsFile("HttpCorrelationOpenApiResponseHeaders.cs"));
+               Assert.False(project.ContainsFile("OpenApiConfigurationOptions.cs"));
+            }
+        }
+
+        [Fact]
+        public async Task Create_WithOpenApiDocs_RemovesOpenApiFiles()
+        {
+            // Arrange
+            var options = new AzureFunctionsHttpProjectOptions();
+
+            using (var project = await AzureFunctionsHttpProject.StartNewAsync(options, _outputWriter))
+            {
+                project.TearDownOptions = TearDownOptions.KeepProjectDirectory;
+                // Assert
+                Assert.True(project.ContainsFile("HttpCorrelationOpenApiResponseHeaders.cs"), "should contain OpenApi response headers file");
+                Assert.True(project.ContainsFile("OpenApiConfigurationOptions.cs"), "should contain OpenApi configuration options file");
+            }
         }
         
         [Theory]

--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/Http/Swagger/SwaggerOpenApiTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/Http/Swagger/SwaggerOpenApiTests.cs
@@ -112,7 +112,6 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions.Http.Swagger
 
             using (var project = await AzureFunctionsHttpProject.StartNewAsync(options, _outputWriter))
             {
-                project.TearDownOptions = TearDownOptions.KeepProjectDirectory;
                 // Assert
                 Assert.True(project.ContainsFile("HttpCorrelationOpenApiResponseHeaders.cs"), "should contain OpenApi response headers file");
                 Assert.True(project.ContainsFile("OpenApiConfigurationOptions.cs"), "should contain OpenApi configuration options file");

--- a/src/Arcus.Templates.Tests.Integration/Fixture/TemplateProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/Fixture/TemplateProject.cs
@@ -352,6 +352,19 @@ namespace Arcus.Templates.Tests.Integration.Fixture
         }
 
         /// <summary>
+        /// Determines whether or not a file is present in the resulting project directory.
+        /// </summary>
+        /// <param name="fileName">The file name (without path) that should be present in the resulting project directory.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="fileName"/> is blank.</exception>
+        public bool ContainsFile(string fileName)
+        {
+            Guard.NotNullOrWhitespace(fileName, nameof(fileName), "Requires a non-blank file name to determine whether the file is present in the resulting project directory");
+
+            string filePath = Path.Combine(ProjectDirectory.FullName, fileName);
+            return File.Exists(filePath);
+        }
+
+        /// <summary>
         /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
         /// </summary>
         public void Dispose()


### PR DESCRIPTION
The OpenApi functionality wasn't all excluded from the resulting project when using the `exclude-openApi` project option in the Azure Functions HTTP trigger project templates.

Closes #616