### PR TITLE
feat: add observability v2.5 to worker templates

### DIFF
--- a/build/templates/docker-integration-tests.yml
+++ b/build/templates/docker-integration-tests.yml
@@ -45,6 +45,7 @@ stages:
               script: |
                 Get-Content './Arcus.Demo.ServiceBus.Queue/Program.cs' | 
                   Where-Object { $_ -notmatch '#error' -and $_ -notmatch 'secretProvider: null' -and $_ -notmatch 'EmptyMessageHandler' -and $_ -notmatch 'AddServiceBusQueueMessagePump' } | 
+                  Where-Object { $_ -notmatch 'AddAzureKeyVaultWithManagedIdentity' } |
                   Set-Content './Arcus.Demo.ServiceBus.Queue/Program.cs'
               envVars: |
                 ARCUS_HEALTH_PORT=$(Arcus.ServiceBus.Queue.Worker.HealthPort)
@@ -60,10 +61,11 @@ stages:
               script: |
                 Get-Content './Arcus.Demo.ServiceBus.Topic/Program.cs' | 
                   Where-Object { $_ -notmatch '#error' -and $_ -notmatch 'secretProvider: null' -and $_ -notmatch 'EmptyMessageHandler' -and $_ -notmatch 'AddServiceBusTopicMessagePump' } | 
+                  Where-Object { $_ -notmatch 'AddAzureKeyVaultWithManagedIdentity' } |
                   Set-Content './Arcus.Demo.ServiceBus.Topic/Program.cs'
               envVars: |
                 ARCUS_HEALTH_PORT=$(Arcus.ServiceBus.Topic.Worker.HealthPort)
-                 EVENTGRID_TOPIC_URI=$(Arcus.Worker.EventGrid.TopicUri)
+                EVENTGRID_TOPIC_URI=$(Arcus.Worker.EventGrid.TopicUri)
                 EVENTGRID_AUTH_KEY=$(Arcus.Worker.EventGrid.AuthKey)
                 ARCUS_SERVICEBUS_CONNECTIONSTRING=$(Arcus.Worker.ServiceBus.Topic.ConnectionString)
                 APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=$(Arcus.ApplicationInsights.InstrumentationKey)
@@ -130,4 +132,13 @@ stages:
             inputs:
               targetType: 'inline'
               script: 'docker logs Arcus.Demo.WebApi'
-            condition: failed()
+          - task: PowerShell@2
+            displayName: 'Get Docker container logs for Arcus.Demo.ServiceBus.Topic'
+            inputs:
+              targetType: 'inline'
+              script: 'docker logs Arcus.Demo.ServiceBus.Topic'
+          - task: PowerShell@2
+            displayName: 'Get Docker container logs for Arcus.Demo.ServiceBus.Queue'
+            inputs:
+              targetType: 'inline'
+              script: 'docker logs Arcus.Demo.ServiceBus.Queue'

--- a/build/templates/docker-integration-tests.yml
+++ b/build/templates/docker-integration-tests.yml
@@ -45,7 +45,7 @@ stages:
               script: |
                 Get-Content './Arcus.Demo.ServiceBus.Queue/Program.cs' | 
                   Where-Object { $_ -notmatch '#error' -and $_ -notmatch 'secretProvider: null' -and $_ -notmatch 'EmptyMessageHandler' -and $_ -notmatch 'AddServiceBusQueueMessagePump' } | 
-                  Where-Object { $_ -notmatch 'AddAzureKeyVaultWithManagedIdentity' } |
+                  Where-Object { $_ -notmatch 'AddAzureKeyVaultWithManagedIdentity' -notmatch '#if DEBUG' -and -notmatch '#endif' } |
                   Set-Content './Arcus.Demo.ServiceBus.Queue/Program.cs'
               envVars: |
                 ARCUS_HEALTH_PORT=$(Arcus.ServiceBus.Queue.Worker.HealthPort)
@@ -61,7 +61,7 @@ stages:
               script: |
                 Get-Content './Arcus.Demo.ServiceBus.Topic/Program.cs' | 
                   Where-Object { $_ -notmatch '#error' -and $_ -notmatch 'secretProvider: null' -and $_ -notmatch 'EmptyMessageHandler' -and $_ -notmatch 'AddServiceBusTopicMessagePump' } | 
-                  Where-Object { $_ -notmatch 'AddAzureKeyVaultWithManagedIdentity' } |
+                  Where-Object { $_ -notmatch 'AddAzureKeyVaultWithManagedIdentity' -notmatch '#if DEBUG' -and -notmatch '#endif' } |
                   Set-Content './Arcus.Demo.ServiceBus.Topic/Program.cs'
               envVars: |
                 ARCUS_HEALTH_PORT=$(Arcus.ServiceBus.Topic.Worker.HealthPort)

--- a/build/templates/docker-integration-tests.yml
+++ b/build/templates/docker-integration-tests.yml
@@ -51,7 +51,7 @@ stages:
                 EVENTGRID_TOPIC_URI=$(Arcus.Worker.EventGrid.TopicUri)
                 EVENTGRID_AUTH_KEY=$(Arcus.Worker.EventGrid.AuthKey)
                 ARCUS_SERVICEBUS_CONNECTIONSTRING=$(Arcus.Worker.ServiceBus.Queue.ConnectionString)
-                TELEMETRY_APPLICATIONINSIGHTS_INSTRUMENTATIONKEY=$(Arcus.ApplicationInsights.InstrumentationKey)
+                APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=$(Arcus.ApplicationInsights.InstrumentationKey)
           - template: 'run-new-project-from-template.yml'
             parameters:
               projectName: 'Arcus.Demo.ServiceBus.Topic'
@@ -66,7 +66,7 @@ stages:
                  EVENTGRID_TOPIC_URI=$(Arcus.Worker.EventGrid.TopicUri)
                 EVENTGRID_AUTH_KEY=$(Arcus.Worker.EventGrid.AuthKey)
                 ARCUS_SERVICEBUS_CONNECTIONSTRING=$(Arcus.Worker.ServiceBus.Topic.ConnectionString)
-                TELEMETRY_APPLICATIONINSIGHTS_INSTRUMENTATIONKEY=$(Arcus.ApplicationInsights.InstrumentationKey)
+                APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=$(Arcus.ApplicationInsights.InstrumentationKey)
           - template: 'run-new-project-from-template.yml'
             parameters:
               projectName: 'Arcus.Demo.AzureFunctions.Databricks.JobMetrics'

--- a/build/templates/docker-integration-tests.yml
+++ b/build/templates/docker-integration-tests.yml
@@ -45,7 +45,7 @@ stages:
               script: |
                 Get-Content './Arcus.Demo.ServiceBus.Queue/Program.cs' | 
                   Where-Object { $_ -notmatch '#error' -and $_ -notmatch 'secretProvider: null' -and $_ -notmatch 'EmptyMessageHandler' -and $_ -notmatch 'AddServiceBusQueueMessagePump' } | 
-                  Where-Object { $_ -notmatch 'AddAzureKeyVaultWithManagedIdentity' -and -notmatch '#if DEBUG' -and -notmatch '#endif' } |
+                  Where-Object { $_ -notmatch 'AddAzureKeyVaultWithManagedIdentity' -and $_ -notmatch '#if DEBUG' -and $_ -notmatch '#endif' } |
                   Set-Content './Arcus.Demo.ServiceBus.Queue/Program.cs'
               envVars: |
                 ARCUS_HEALTH_PORT=$(Arcus.ServiceBus.Queue.Worker.HealthPort)
@@ -61,7 +61,7 @@ stages:
               script: |
                 Get-Content './Arcus.Demo.ServiceBus.Topic/Program.cs' | 
                   Where-Object { $_ -notmatch '#error' -and $_ -notmatch 'secretProvider: null' -and $_ -notmatch 'EmptyMessageHandler' -and $_ -notmatch 'AddServiceBusTopicMessagePump' } | 
-                  Where-Object { $_ -notmatch 'AddAzureKeyVaultWithManagedIdentity' -and -notmatch '#if DEBUG' -and -notmatch '#endif' } |
+                  Where-Object { $_ -notmatch 'AddAzureKeyVaultWithManagedIdentity' -and $_ -notmatch '#if DEBUG' -and $_ -notmatch '#endif' } |
                   Set-Content './Arcus.Demo.ServiceBus.Topic/Program.cs'
               envVars: |
                 ARCUS_HEALTH_PORT=$(Arcus.ServiceBus.Topic.Worker.HealthPort)

--- a/build/templates/docker-integration-tests.yml
+++ b/build/templates/docker-integration-tests.yml
@@ -132,6 +132,7 @@ stages:
             inputs:
               targetType: 'inline'
               script: 'docker logs Arcus.Demo.WebApi'
+            condition: failed()
           - task: PowerShell@2
             displayName: 'Get Docker container logs for Arcus.Demo.ServiceBus.Topic'
             inputs:

--- a/build/templates/docker-integration-tests.yml
+++ b/build/templates/docker-integration-tests.yml
@@ -45,7 +45,7 @@ stages:
               script: |
                 Get-Content './Arcus.Demo.ServiceBus.Queue/Program.cs' | 
                   Where-Object { $_ -notmatch '#error' -and $_ -notmatch 'secretProvider: null' -and $_ -notmatch 'EmptyMessageHandler' -and $_ -notmatch 'AddServiceBusQueueMessagePump' } | 
-                  Where-Object { $_ -notmatch 'AddAzureKeyVaultWithManagedIdentity' -notmatch '#if DEBUG' -and -notmatch '#endif' } |
+                  Where-Object { $_ -notmatch 'AddAzureKeyVaultWithManagedIdentity' -and -notmatch '#if DEBUG' -and -notmatch '#endif' } |
                   Set-Content './Arcus.Demo.ServiceBus.Queue/Program.cs'
               envVars: |
                 ARCUS_HEALTH_PORT=$(Arcus.ServiceBus.Queue.Worker.HealthPort)
@@ -61,7 +61,7 @@ stages:
               script: |
                 Get-Content './Arcus.Demo.ServiceBus.Topic/Program.cs' | 
                   Where-Object { $_ -notmatch '#error' -and $_ -notmatch 'secretProvider: null' -and $_ -notmatch 'EmptyMessageHandler' -and $_ -notmatch 'AddServiceBusTopicMessagePump' } | 
-                  Where-Object { $_ -notmatch 'AddAzureKeyVaultWithManagedIdentity' -notmatch '#if DEBUG' -and -notmatch '#endif' } |
+                  Where-Object { $_ -notmatch 'AddAzureKeyVaultWithManagedIdentity' -and -notmatch '#if DEBUG' -and -notmatch '#endif' } |
                   Set-Content './Arcus.Demo.ServiceBus.Topic/Program.cs'
               envVars: |
                 ARCUS_HEALTH_PORT=$(Arcus.ServiceBus.Topic.Worker.HealthPort)

--- a/build/templates/docker-integration-tests.yml
+++ b/build/templates/docker-integration-tests.yml
@@ -138,8 +138,10 @@ stages:
             inputs:
               targetType: 'inline'
               script: 'docker logs Arcus.Demo.ServiceBus.Topic'
+            condition: failed()
           - task: PowerShell@2
             displayName: 'Get Docker container logs for Arcus.Demo.ServiceBus.Queue'
             inputs:
               targetType: 'inline'
               script: 'docker logs Arcus.Demo.ServiceBus.Queue'
+            condition: failed()

--- a/src/Arcus.Templates.ServiceBus.Queue/Arcus.Templates.ServiceBus.Queue.csproj
+++ b/src/Arcus.Templates.ServiceBus.Queue/Arcus.Templates.ServiceBus.Queue.csproj
@@ -50,10 +50,10 @@
   <ItemGroup>
     <PackageReference Include="Arcus.Messaging.Health" Version="1.2.0" />
     <PackageReference Include="Arcus.Messaging.Pumps.ServiceBus" Version="1.2.0" />
-    <PackageReference Include="Arcus.Observability.Correlation" Version="2.4.0" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.4.0" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Filters" Version="2.4.0" Condition="'$(Serilog)' == 'true'" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="2.4.0" Condition="'$(Serilog)' == 'true'" />
+    <PackageReference Include="Arcus.Observability.Correlation" Version="2.5.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.5.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Filters" Version="2.5.0" Condition="'$(Serilog)' == 'true'" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="2.5.0" Condition="'$(Serilog)' == 'true'" />
     <PackageReference Include="Arcus.Security.Core" Version="1.7.0" />
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.7.0" />
     <PackageReference Include="Guard.NET" Version="2.0.0" />

--- a/src/Arcus.Templates.ServiceBus.Queue/Program.cs
+++ b/src/Arcus.Templates.ServiceBus.Queue/Program.cs
@@ -17,7 +17,7 @@ namespace Arcus.Templates.ServiceBus.Queue
     public class Program
     {
 #if Serilog
-        #warning Make sure that the your Azure Application Insights connection string key is available as a secret.
+        #warning Make sure that the Azure Application Insights connection string key is available as a secret.
         private const string ApplicationInsightsConnectionStringKeyName = "APPLICATIONINSIGHTS_CONNECTION_STRING";
         
 #endif

--- a/src/Arcus.Templates.ServiceBus.Queue/Program.cs
+++ b/src/Arcus.Templates.ServiceBus.Queue/Program.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Threading.Tasks;
+using Arcus.Security.Core;
 using Arcus.Security.Core.Caching.Configuration;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -7,6 +9,7 @@ using Microsoft.Extensions.Hosting;
 using Serilog;
 using Serilog.Configuration;
 using Serilog.Events;
+using Serilog.Extensions.Hosting;
 #endif
 
 namespace Arcus.Templates.ServiceBus.Queue
@@ -14,24 +17,24 @@ namespace Arcus.Templates.ServiceBus.Queue
     public class Program
     {
 #if Serilog
-        #warning Make sure that the appsettings.json is updated with your Azure Application Insights instrumentation key.
-        private const string ApplicationInsightsInstrumentationKeyName = "APPINSIGHTS_INSTRUMENTATIONKEY";
+        #warning Make sure that the your Azure Application Insights connection string key is available as a secret.
+        private const string ApplicationInsightsConnectionStringKeyName = "APPLICATIONINSIGHTS_CONNECTION_STRING";
         
 #endif
-        public static int Main(string[] args)
+        public static async Task<int> Main(string[] args)
         {
 #if Serilog
             Log.Logger = new LoggerConfiguration()
                 .MinimumLevel.Debug()
                 .WriteTo.Console()
-                .CreateLogger();
+                .CreateBootstrapLogger();
             
             try
             {
-                CreateHostBuilder(args)
-                    .Build()
-                    .Run();
-
+                IHost host = CreateHostBuilder(args).Build();
+                await ConfigureSerilogAsync(host);
+                await host.RunAsync();
+                
                 return 0;
             }
             catch (Exception exception)
@@ -70,7 +73,7 @@ namespace Arcus.Templates.ServiceBus.Queue
                            stores.AddAzureKeyVaultWithManagedIdentity("https://your-keyvault.vault.azure.net/", CacheConfiguration.Default);
                        })
 #if Serilog
-                       .UseSerilog(UpdateLoggerConfiguration)
+                       .UseSerilog(Log.Logger)
 #endif
                        .ConfigureServices((hostContext, services) =>
                        {
@@ -82,22 +85,28 @@ namespace Arcus.Templates.ServiceBus.Queue
         }
 #if Serilog
         
-        private static void UpdateLoggerConfiguration(
-            HostBuilderContext hostContext,
-            LoggerConfiguration config)
+        private static async Task ConfigureSerilogAsync(IHost host)
         {
-            config.MinimumLevel.Debug()
-                  .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
-                  .Enrich.FromLogContext()
-                  .Enrich.WithVersion()
-                  .Enrich.WithComponentName("Service Bus Queue Worker")
-                  .WriteTo.Console();
+            var secretProvider = host.Services.GetRequiredService<ISecretProvider>();
+            string connectionString = await secretProvider.GetRawSecretAsync(ApplicationInsightsConnectionStringKeyName);
             
-            var instrumentationKey = hostContext.Configuration.GetValue<string>(ApplicationInsightsInstrumentationKeyName);
-            if (!string.IsNullOrWhiteSpace(instrumentationKey))
+            var reloadLogger = (ReloadableLogger) Log.Logger;
+            reloadLogger.Reload(config =>
             {
-                config.WriteTo.AzureApplicationInsights(instrumentationKey);
-            }
+                config.MinimumLevel.Debug()
+                      .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
+                      .Enrich.FromLogContext()
+                      .Enrich.WithVersion()
+                      .Enrich.WithComponentName("Service Bus Queue Worker")
+                      .WriteTo.Console();
+                
+                if (!string.IsNullOrWhiteSpace(connectionString))
+                {
+                    config.WriteTo.AzureApplicationInsightsWithConnectionString(connectionString);
+                }
+                
+                return config;
+            });
         }
 #endif
     }

--- a/src/Arcus.Templates.ServiceBus.Topic/Arcus.Templates.ServiceBus.Topic.csproj
+++ b/src/Arcus.Templates.ServiceBus.Topic/Arcus.Templates.ServiceBus.Topic.csproj
@@ -50,10 +50,10 @@
   <ItemGroup>
     <PackageReference Include="Arcus.Messaging.Health" Version="1.2.0" />
     <PackageReference Include="Arcus.Messaging.Pumps.ServiceBus" Version="1.2.0" />
-    <PackageReference Include="Arcus.Observability.Correlation" Version="2.4.0" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.4.0" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Filters" Version="2.4.0" Condition="'$(Serilog)' == 'true'" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="2.4.0" Condition="'$(Serilog)' == 'true'" />
+    <PackageReference Include="Arcus.Observability.Correlation" Version="2.5.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.5.0" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Filters" Version="2.5.0" Condition="'$(Serilog)' == 'true'" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="2.5.0" Condition="'$(Serilog)' == 'true'" />
     <PackageReference Include="Arcus.Security.Core" Version="1.7.0" />
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.7.0" />
     <PackageReference Include="Guard.NET" Version="2.0.0" />

--- a/src/Arcus.Templates.ServiceBus.Topic/Program.cs
+++ b/src/Arcus.Templates.ServiceBus.Topic/Program.cs
@@ -17,7 +17,7 @@ namespace Arcus.Templates.ServiceBus.Topic
     public class Program
     {
 #if Serilog
-        #warning Make sure that the your Azure Application Insights connection string key is available as a secret.
+        #warning Make sure that the Azure Application Insights connection string key is available as a secret.
         private const string ApplicationInsightsConnectionStringKeyName = "APPLICATIONINSIGHTS_CONNECTION_STRING";
         
 #endif

--- a/src/Arcus.Templates.ServiceBus.Topic/Program.cs
+++ b/src/Arcus.Templates.ServiceBus.Topic/Program.cs
@@ -1,15 +1,15 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Arcus.Security.Core;
 using Arcus.Security.Core.Caching.Configuration;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Serilog.Extensions.Hosting;
 #if Serilog
-using Arcus.Security.Core;
 using Serilog;
 using Serilog.Configuration;
 using Serilog.Events;
+using Serilog.Extensions.Hosting;
 #endif
 
 namespace Arcus.Templates.ServiceBus.Topic

--- a/src/Arcus.Templates.ServiceBus.Topic/Program.cs
+++ b/src/Arcus.Templates.ServiceBus.Topic/Program.cs
@@ -1,9 +1,12 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Arcus.Security.Core.Caching.Configuration;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Serilog.Extensions.Hosting;
 #if Serilog
+using Arcus.Security.Core;
 using Serilog;
 using Serilog.Configuration;
 using Serilog.Events;
@@ -14,24 +17,24 @@ namespace Arcus.Templates.ServiceBus.Topic
     public class Program
     {
 #if Serilog
-        #warning Make sure that the appsettings.json is updated with your Azure Application Insights instrumentation key.
-        private const string ApplicationInsightsInstrumentationKeyName = "APPINSIGHTS_INSTRUMENTATIONKEY";
-
+        #warning Make sure that the your Azure Application Insights connection string key is available as a secret.
+        private const string ApplicationInsightsConnectionStringKeyName = "APPLICATIONINSIGHTS_CONNECTION_STRING";
+        
 #endif
-        public static int Main(string[] args)
+        public static async Task<int> Main(string[] args)
         {
 #if Serilog
             Log.Logger = new LoggerConfiguration()
                 .MinimumLevel.Debug()
                 .WriteTo.Console()
-                .CreateLogger();
-
+                .CreateBootstrapLogger();
+            
             try
             {
-                CreateHostBuilder(args)
-                    .Build()
-                    .Run();
-
+                IHost host = CreateHostBuilder(args).Build();
+                await ConfigureSerilogAsync(host);
+                await host.RunAsync();
+                
                 return 0;
             }
             catch (Exception exception)
@@ -44,14 +47,13 @@ namespace Arcus.Templates.ServiceBus.Topic
                 Log.CloseAndFlush();
             }
 #else
-            CreateHostBuilder(args)
-                .Build()
-                .Run();
-
+            IHost host = CreateHostBuilder(args).Build();
+            await host.RunAsync();
+            
             return 0;
 #endif
         }
-
+        
         public static IHostBuilder CreateHostBuilder(string[] args)
         {
             return Host.CreateDefaultBuilder(args)
@@ -65,12 +67,12 @@ namespace Arcus.Templates.ServiceBus.Topic
 //[#if DEBUG]
                            stores.AddConfiguration(config);
 //[#endif]
-
+                            
                            //#error Please provide a valid secret provider, for example Azure Key Vault: https://security.arcus-azure.net/features/secret-store/provider/key-vault
                            stores.AddAzureKeyVaultWithManagedIdentity("https://your-keyvault.vault.azure.net/", CacheConfiguration.Default);
                        })
 #if Serilog
-                       .UseSerilog(UpdateLoggerConfiguration)
+                       .UseSerilog(Log.Logger)
 #endif
                        .ConfigureServices((hostContext, services) =>
                        {
@@ -82,22 +84,28 @@ namespace Arcus.Templates.ServiceBus.Topic
         }
 #if Serilog
         
-        private static void UpdateLoggerConfiguration(
-            HostBuilderContext hostContext,
-            LoggerConfiguration config)
+        private static async Task ConfigureSerilogAsync(IHost host)
         {
-            config.MinimumLevel.Debug()
-                  .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
-                  .Enrich.FromLogContext()
-                  .Enrich.WithVersion()
-                  .Enrich.WithComponentName("Service Bus Topic Worker")
-                  .WriteTo.Console();
+            var secretProvider = host.Services.GetRequiredService<ISecretProvider>();
+            string connectionString = await secretProvider.GetRawSecretAsync(ApplicationInsightsConnectionStringKeyName);
             
-            var instrumentationKey = hostContext.Configuration.GetValue<string>(ApplicationInsightsInstrumentationKeyName);
-            if (!string.IsNullOrWhiteSpace(instrumentationKey))
+            var reloadLogger = (ReloadableLogger) Log.Logger;
+            reloadLogger.Reload(config =>
             {
-                config.WriteTo.AzureApplicationInsights(instrumentationKey);
-            }
+                config.MinimumLevel.Debug()
+                      .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
+                      .Enrich.FromLogContext()
+                      .Enrich.WithVersion()
+                      .Enrich.WithComponentName("Service Bus Topic Worker")
+                      .WriteTo.Console();
+                
+                if (!string.IsNullOrWhiteSpace(connectionString))
+                {
+                    config.WriteTo.AzureApplicationInsightsWithConnectionString(connectionString);
+                }
+                
+                return config;
+            });
         }
 #endif
     }

--- a/src/Arcus.Templates.Tests.Integration/Worker/ServiceBusWorkerProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/Worker/ServiceBusWorkerProject.cs
@@ -9,6 +9,7 @@ using Arcus.Templates.Tests.Integration.Worker.Configuration;
 using Arcus.Templates.Tests.Integration.Worker.Fixture;
 using Arcus.Templates.Tests.Integration.Worker.Health;
 using Arcus.Templates.Tests.Integration.Worker.MessagePump;
+using Azure.Messaging.ServiceBus;
 using GuardNet;
 using Polly;
 using Xunit.Abstractions;
@@ -165,16 +166,13 @@ namespace Arcus.Templates.Tests.Integration.Worker
             AddTypeAsFile<OrderCreatedEvent>();
             AddTypeAsFile<OrderCreatedEventData>();
             AddTypeAsFile<OrdersMessageHandler>();
-            AddTypeAsFile<SingleValueSecretProvider>();
-
-            string connectionString = _configuration.GetServiceBusConnectionString(_entity);
+            
             UpdateFileInProject("Program.cs", contents => 
                 RemovesUserErrorsFromContents(contents)
                     .Replace(".MinimumLevel.Debug()", ".MinimumLevel.Verbose()")
                     .Replace("EmptyMessageHandler", nameof(OrdersMessageHandler))
                     .Replace("EmptyMessage", nameof(Order))
-                    .Replace("AddAzureKeyVaultWithManagedIdentity(\"https://your-keyvault.vault.azure.net/\", CacheConfiguration.Default)", 
-                             $"AddProvider(new {nameof(SingleValueSecretProvider)}(\"{connectionString}\"))"));
+                    .Replace("stores.AddAzureKeyVaultWithManagedIdentity(\"https://your-keyvault.vault.azure.net/\", CacheConfiguration.Default);", ""));
         }
 
         private async Task StartAsync(ServiceBusWorkerProjectOptions options)

--- a/src/Arcus.Templates.Tests.Integration/Worker/ServiceBusWorkerProjectOptions.cs
+++ b/src/Arcus.Templates.Tests.Integration/Worker/ServiceBusWorkerProjectOptions.cs
@@ -11,7 +11,7 @@ namespace Arcus.Templates.Tests.Integration.Worker
     /// </summary>
     public class ServiceBusWorkerProjectOptions : ProjectOptions
     {
-        private const string SerilogTelemetryInstrumentationKey = "TELEMETRY_APPLICATIONINSIGHTS_INSTRUMENTATIONKEY";
+        private const string ApplicationInsightsConnectionStringKey = "APPLICATIONINSIGHTS_CONNECTION_STRING";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ServiceBusWorkerProjectOptions"/> class.
@@ -43,14 +43,16 @@ namespace Arcus.Templates.Tests.Integration.Worker
         public IEnumerable<CommandArgument> AdditionalArguments { get; }
 
         /// <summary>
-        /// 
+        /// Creates an <see cref="ServiceBusWorkerProjectOptions"/> instance that provides additional user-configurable options for the Azure Service Bus .NET Worker projects.
         /// </summary>
-        /// <param name="configuration"></param>
-        /// <returns></returns>
+        /// <param name="configuration">The integration test configuration instance to retrieve connection secrets.</param>
+        /// <exception cref="ArgumentNullException">Thrown when the <paramref name="configuration"/> is <c>null</c>.</exception>
         public static ServiceBusWorkerProjectOptions Create(TestConfig configuration)
         {
+            Guard.NotNull(configuration, nameof(configuration), "Requires a test configuration instance to retrieve additional connection secrets");
+
             string instrumentationKey = configuration.GetApplicationInsightsInstrumentationKey();
-            var commandArgument = CommandArgument.CreateSecret(SerilogTelemetryInstrumentationKey, instrumentationKey);
+            var commandArgument = CommandArgument.CreateSecret(ApplicationInsightsConnectionStringKey, $"InstrumentationKey={instrumentationKey}");
 
             return new ServiceBusWorkerProjectOptions(new[] { commandArgument });
         }
@@ -61,7 +63,7 @@ namespace Arcus.Templates.Tests.Integration.Worker
         public ServiceBusWorkerProjectOptions WithExcludeSerilog()
         {
             ProjectOptions optionsWithoutSerilog = AddOption("--exclude-serilog");
-            IEnumerable<CommandArgument> argumentsWithoutSerilog = AdditionalArguments.Where(arg => arg.Name != SerilogTelemetryInstrumentationKey);
+            IEnumerable<CommandArgument> argumentsWithoutSerilog = AdditionalArguments.Where(arg => arg.Name != ApplicationInsightsConnectionStringKey);
             
             return new ServiceBusWorkerProjectOptions(argumentsWithoutSerilog, optionsWithoutSerilog);
         }


### PR DESCRIPTION
Uses Observability v2.5 in both Azure Service Bus .NET Worker project templates.
* Uses Application Insights connection string instead of instrumentation key
* Uses Arcus secret store to retrieve the connection string

Relates to #620