### PR TITLE
test: add integration test for webapi w/ excluded exception in health report

### DIFF
--- a/src/Arcus.Templates.Tests.Integration/WebApi/Authentication/v1/JwtAuthenticationOptionTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/WebApi/Authentication/v1/JwtAuthenticationOptionTests.cs
@@ -98,12 +98,13 @@ namespace Arcus.Templates.Tests.Integration.WebApi.Authentication.v1
 
                         Assert.NotNull(document.Components);
                         (string schemeName, OpenApiSecurityScheme componentScheme) = Assert.Single(document.Components.SecuritySchemes);
+                        Assert.Equal("Bearer", schemeName);
                         Assert.Equal(SecuritySchemeType.Http, componentScheme.Type);
                         
                         OpenApiSecurityRequirement requirement = Assert.Single(document.SecurityRequirements);
                         Assert.NotNull(requirement);
                         (OpenApiSecurityScheme requirementScheme, IList<string> scopes) = Assert.Single(requirement);
-                        Assert.Equal("jwt", requirementScheme.Reference.Id);
+                        Assert.Equal("Bearer", requirementScheme.Reference.Id);
                     }
                 }
             }

--- a/src/Arcus.Templates.WebApi/Program.cs
+++ b/src/Arcus.Templates.WebApi/Program.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 #if Console
 using Microsoft.Extensions.Logging; 

--- a/src/Arcus.Templates.WebApi/Program.cs
+++ b/src/Arcus.Templates.WebApi/Program.cs
@@ -270,7 +270,7 @@ namespace Arcus.Templates.WebApi
 #endif
 #if JwtAuth
                 
-                swaggerGenerationOptions.AddSecurityDefinition("jwt", new OpenApiSecurityScheme
+                swaggerGenerationOptions.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
                 {
                     Type = SecuritySchemeType.Http,
                     Description = "Authentication scheme based on JWT"
@@ -280,10 +280,11 @@ namespace Arcus.Templates.WebApi
                     {
                         new OpenApiSecurityScheme
                         {
+                            Scheme = "bearer",
                             Description = "Globally authentication scheme based on JWT",
                             Reference = new OpenApiReference
                             {
-                                Id = "jwt",
+                                Id = "Bearer",
                                 Type = ReferenceType.SecurityScheme
                             }
                         }, new List<string>()


### PR DESCRIPTION
Adds an integration test that verifies that we indeed removes the exception details when the application's health is unhealthy.