### PR TITLE
feat: use appinsights connectionstring in http trigger

### DIFF
--- a/build/templates/docker-integration-tests.yml
+++ b/build/templates/docker-integration-tests.yml
@@ -92,7 +92,7 @@ stages:
                   Where-Object { $_ -notmatch '#error' } |
                   Set-Content './Arcus.Demo.AzureFunctions.Http/Startup.cs'
               envVars: |
-                APPLICATIONINSIGHTS_INSTRUMENTATIONKEY=$(Arcus.ApplicationInsights.InstrumentationKey)
+                APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=$(Arcus.ApplicationInsights.InstrumentationKey)
           - template: 'run-new-project-from-template.yml'
             parameters:
               projectName: 'Arcus.Demo.AzureFunctions.ServiceBus.Queue'

--- a/src/Arcus.Templates.AzureFunctions.Http/Arcus.Templates.AzureFunctions.Http.csproj
+++ b/src/Arcus.Templates.AzureFunctions.Http/Arcus.Templates.AzureFunctions.Http.csproj
@@ -26,7 +26,7 @@
     <EnableDefaultContentItems>false</EnableDefaultContentItems>
     <DockerComposeProjectPath>..\Arcus.Templates.Orchestrator.dcproj</DockerComposeProjectPath>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>NU5048;NU5125;NU5119;NU5128;CS0618</NoWarn>
+    <NoWarn>NU5048;NU5125;NU5119;NU5128</NoWarn>
     <!--#endif-->
   </PropertyGroup>
 
@@ -65,7 +65,7 @@
     <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.Applicationinsights" Version="2.5.0" />
     <PackageReference Include="Arcus.Security.AzureFunctions" Version="1.7.0" />
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.7.0" />
-    <PackageReference Include="Arcus.WebApi.Logging.AzureFunctions" Version="1.5.0" />
+    <PackageReference Include="Arcus.WebApi.Logging.AzureFunctions" Version="1.6.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="4.0.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.12" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.OpenApi" Version="1.3.0" Condition="'$(OpenApi)' == 'true'" />

--- a/src/Arcus.Templates.AzureFunctions.Http/Startup.cs
+++ b/src/Arcus.Templates.AzureFunctions.Http/Startup.cs
@@ -69,10 +69,10 @@ namespace Arcus.Templates.AzureFunctions.Http
                 .WriteTo.Console();
             
             IConfiguration appConfig = builder.GetContext().Configuration;
-            var instrumentationKey = appConfig.GetValue<string>("APPINSIGHTS_INSTRUMENTATIONKEY");
-            if (!string.IsNullOrWhiteSpace(instrumentationKey))
+            var connectionString = appConfig.GetValue<string>("APPLICATIONINSIGHTS_CONNECTION_STRING");
+            if (!string.IsNullOrWhiteSpace(connectionString))
             {
-                configuration.WriteTo.AzureApplicationInsights(instrumentationKey);
+                configuration.WriteTo.AzureApplicationInsightsWithConnectionString(connectionString);
             }
             
             return configuration;

--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/AzureFunctionsProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/AzureFunctionsProject.cs
@@ -19,7 +19,8 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions
     /// </summary>
     public abstract class AzureFunctionsProject : TemplateProject
     {
-        protected const string ApplicationInsightsInstrumentationKeyVariable = "APPINSIGHTS_INSTRUMENTATIONKEY";
+        protected const string ApplicationInsightsInstrumentationKeyVariable = "APPINSIGHTS_INSTRUMENTATIONKEY",
+                               ApplicationInsightsConnectionStringKeyVariable = "APPLICATIONINSIGHTS_CONNECTION_STRING";
 
         private static readonly HttpClient HttpClient = new HttpClient();
         
@@ -109,6 +110,7 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions
             Logger.WriteLine("> {0} {1}", processInfo.FileName, processInfo.Arguments);
 
             Environment.SetEnvironmentVariable(ApplicationInsightsInstrumentationKeyVariable, ApplicationInsightsConfig.InstrumentationKey);
+            Environment.SetEnvironmentVariable(ApplicationInsightsConnectionStringKeyVariable, $"InstrumentationKey={ApplicationInsightsConfig.InstrumentationKey}");
             return processInfo;
         }
 
@@ -163,6 +165,7 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions
         protected override void Disposing(bool disposing)
         {
             Environment.SetEnvironmentVariable(ApplicationInsightsInstrumentationKeyVariable, null);
+            Environment.SetEnvironmentVariable(ApplicationInsightsConnectionStringKeyVariable, null);
         }
     }
 }

--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/Http/Api/HttpTriggerOrderTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/Http/Api/HttpTriggerOrderTests.cs
@@ -54,7 +54,6 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions.Http.Api
                     
                     IEnumerable<string> responseHeaderNames = response.Headers.Select(header => header.Key).ToArray();
                     Assert.Contains("X-Transaction-ID", responseHeaderNames);
-                    Assert.Contains("RequestId", responseHeaderNames);
                 }
             }
         }

--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/Http/Health/HealthChecksTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/Http/Health/HealthChecksTests.cs
@@ -43,7 +43,6 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions.Http.Health
                 {
                     // Assert
                     Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-                    Assert.NotEmpty(response.Headers.GetValues("RequestId"));
                     Assert.NotEmpty(response.Headers.GetValues("X-Transaction-Id"));
                     
                     string healthReportJson = await response.Content.ReadAsStringAsync();

--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/Http/Swagger/SwaggerOpenApiTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/Http/Swagger/SwaggerOpenApiTests.cs
@@ -58,7 +58,6 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions.Http.Swagger
                     
                     IEnumerable<string> responseHeaderNames = response.Headers.Select(header => header.Key).ToArray();
                     Assert.Contains("X-Transaction-ID", responseHeaderNames);
-                    Assert.Contains("RequestId", responseHeaderNames);
                 }
             }
         }
@@ -79,7 +78,6 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions.Http.Swagger
                 {
                     // Assert
                     Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-                    Assert.NotEmpty(response.Headers.GetValues("RequestId"));
                     Assert.NotEmpty(response.Headers.GetValues("X-Transaction-Id"));
                     
                     string healthReportJson = await response.Content.ReadAsStringAsync();
@@ -219,7 +217,6 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions.Http.Swagger
                 res =>
                 {
                     Assert.Equal("200", res.Key);
-                    Assert.Contains("RequestId", res.Value.Headers);
                     Assert.Contains("X-Transaction-Id", res.Value.Headers);
                     Assert.Single(res.Value.Content, content => content.Key == "application/json");
                 },
@@ -235,7 +232,6 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions.Http.Swagger
                 res =>
                 {
                     Assert.Equal("200", res.Key);
-                    Assert.Contains("RequestId", res.Value.Headers);
                     Assert.Contains("X-Transaction-Id", res.Value.Headers);
                     Assert.Single(res.Value.Content, content => content.Key == "application/json");
                 },


### PR DESCRIPTION
Use the Application Insights' connection string instead of the instrumentation key to setup the Serilog's Application Insights sink in the Azure Functions HTTP trigger project template.

Relates to #620