### PR TITLE
chore: rename serilog appinsights directive

### DIFF
--- a/src/Arcus.Templates.AzureFunctions.ServiceBus.Queue/.template.config/template.json
+++ b/src/Arcus.Templates.AzureFunctions.ServiceBus.Queue/.template.config/template.json
@@ -69,7 +69,7 @@
       "defaultValue": "false",
       "description": "Exclude the Serilog logging infrastructure in the worker project"
     },
-    "Serilog": {
+    "Serilog_AppInsights": {
       "type": "computed",
       "value": "!(exclude-serilog)"
     }

--- a/src/Arcus.Templates.AzureFunctions.ServiceBus.Queue/Arcus.Templates.AzureFunctions.ServiceBus.Queue.csproj
+++ b/src/Arcus.Templates.AzureFunctions.ServiceBus.Queue/Arcus.Templates.AzureFunctions.ServiceBus.Queue.csproj
@@ -34,8 +34,8 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <DefineConstants>$(DefineConstants);Serilog</DefineConstants>
-    <Serilog>true</Serilog>
+    <DefineConstants>$(DefineConstants);Serilog_AppInsights</DefineConstants>
+    <Serilog_AppInsights>true</Serilog_AppInsights>
     <DockerFastModeProjectMountDirectory>/home/site/wwwroot</DockerFastModeProjectMountDirectory>
   </PropertyGroup>
 
@@ -50,16 +50,16 @@
     <PackageReference Include="Arcus.Observability.Correlation" Version="2.5.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.AzureFunctions" Version="2.5.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.5.0" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Filters" Version="2.5.0" Condition="'$(Serilog)' == 'true'" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="2.5.0" Condition="'$(Serilog)' == 'true'" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Filters" Version="2.5.0" Condition="'$(Serilog_AppInsights)' == 'true'" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="2.5.0" Condition="'$(Serilog_AppInsights)' == 'true'" />
     <PackageReference Include="Arcus.Security.AzureFunctions" Version="1.7.0" />
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.7.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.7.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
-    <PackageReference Include="Serilog" Version="2.11.0" Condition="'$(Serilog)' == 'true'" />
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="5.0.1" Condition="'$(Serilog)' == 'true'" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" Condition="'$(Serilog)' == 'true'" />
+    <PackageReference Include="Serilog" Version="2.11.0" Condition="'$(Serilog_AppInsights)' == 'true'" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="5.0.1" Condition="'$(Serilog_AppInsights)' == 'true'" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" Condition="'$(Serilog_AppInsights)' == 'true'" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Arcus.Templates.AzureFunctions.ServiceBus.Queue/Startup.cs
+++ b/src/Arcus.Templates.AzureFunctions.ServiceBus.Queue/Startup.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-#if Serilog
+#if Serilog_AppInsights
 using Serilog;
 using Serilog.Configuration;
 using Serilog.Events; 
@@ -42,7 +42,7 @@ namespace Arcus.Templates.AzureFunctions.ServiceBus.Queue
             
             builder.AddServiceBusMessageRouting()
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
-#if Serilog
+#if Serilog_AppInsights
             
             LoggerConfiguration logConfig = CreateLoggerConfiguration(builder);
             builder.Services.AddLogging(logging =>
@@ -52,7 +52,7 @@ namespace Arcus.Templates.AzureFunctions.ServiceBus.Queue
             }); 
 #endif
         }
-#if Serilog
+#if Serilog_AppInsights
         
         private static LoggerConfiguration CreateLoggerConfiguration(IFunctionsHostBuilder builder)
         {

--- a/src/Arcus.Templates.AzureFunctions.ServiceBus.Topic/.template.config/template.json
+++ b/src/Arcus.Templates.AzureFunctions.ServiceBus.Topic/.template.config/template.json
@@ -69,7 +69,7 @@
       "defaultValue": "false",
       "description": "Exclude the Serilog logging infrastructure in the worker project"
     },
-    "Serilog": {
+    "Serilog_AppInsights": {
       "type": "computed",
       "value": "!(exclude-serilog)"
     }

--- a/src/Arcus.Templates.AzureFunctions.ServiceBus.Topic/Arcus.Templates.AzureFunctions.ServiceBus.Topic.csproj
+++ b/src/Arcus.Templates.AzureFunctions.ServiceBus.Topic/Arcus.Templates.AzureFunctions.ServiceBus.Topic.csproj
@@ -33,8 +33,8 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <DefineConstants>$(DefineConstants);Serilog</DefineConstants>
-    <Serilog>true</Serilog>
+    <DefineConstants>$(DefineConstants);Serilog_AppInsights</DefineConstants>
+    <Serilog_AppInsights>true</Serilog_AppInsights>
     <DockerFastModeProjectMountDirectory>/home/site/wwwroot</DockerFastModeProjectMountDirectory>
   </PropertyGroup>
 
@@ -49,16 +49,16 @@
     <PackageReference Include="Arcus.Observability.Correlation" Version="2.5.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.AzureFunctions" Version="2.5.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.5.0" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Filters" Version="2.5.0" Condition="'$(Serilog)' == 'true'" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="2.5.0" Condition="'$(Serilog)' == 'true'" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Filters" Version="2.5.0" Condition="'$(Serilog_AppInsights)' == 'true'" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="2.5.0" Condition="'$(Serilog_AppInsights)' == 'true'" />
     <PackageReference Include="Arcus.Security.AzureFunctions" Version="1.7.0" />
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.7.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.7.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
-    <PackageReference Include="Serilog" Version="2.11.0" Condition="'$(Serilog)' == 'true'" />
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="5.0.1" Condition="'$(Serilog)' == 'true'" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" Condition="'$(Serilog)' == 'true'" />
+    <PackageReference Include="Serilog" Version="2.11.0" Condition="'$(Serilog_AppInsights)' == 'true'" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="5.0.1" Condition="'$(Serilog_AppInsights)' == 'true'" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" Condition="'$(Serilog_AppInsights)' == 'true'" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Arcus.Templates.AzureFunctions.ServiceBus.Topic/Startup.cs
+++ b/src/Arcus.Templates.AzureFunctions.ServiceBus.Topic/Startup.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-#if Serilog
+#if Serilog_AppInsights
 using Serilog;
 using Serilog.Configuration;
 using Serilog.Events; 
@@ -42,7 +42,7 @@ namespace Arcus.Templates.AzureFunctions.ServiceBus.Topic
             
             builder.AddServiceBusMessageRouting()
                    .WithServiceBusMessageHandler<OrdersAzureServiceBusMessageHandler, Order>();
-#if Serilog
+#if Serilog_AppInsights
             
             LoggerConfiguration logConfig = CreateLoggerConfiguration(builder);
             builder.Services.AddLogging(logging =>
@@ -52,7 +52,7 @@ namespace Arcus.Templates.AzureFunctions.ServiceBus.Topic
             }); 
 #endif
         }
-#if Serilog
+#if Serilog_AppInsights
         
         private static LoggerConfiguration CreateLoggerConfiguration(IFunctionsHostBuilder builder)
         {

--- a/src/Arcus.Templates.ServiceBus.Queue/.template.config/template.json
+++ b/src/Arcus.Templates.ServiceBus.Queue/.template.config/template.json
@@ -69,7 +69,7 @@
       "defaultValue": "false",
       "description": "Exclude the Serilog logging infrastructure in the worker project"
     },
-    "Serilog": {
+    "Serilog_AppInsights": {
       "type": "computed",
       "value": "!(exclude-serilog)"
     }

--- a/src/Arcus.Templates.ServiceBus.Queue/Arcus.Templates.ServiceBus.Queue.csproj
+++ b/src/Arcus.Templates.ServiceBus.Queue/Arcus.Templates.ServiceBus.Queue.csproj
@@ -38,8 +38,8 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <DefineConstants>$(DefineConstants);Serilog</DefineConstants>
-    <Serilog>true</Serilog>
+    <DefineConstants>$(DefineConstants);Serilog_AppInsights</DefineConstants>
+    <Serilog_AppInsights>true</Serilog_AppInsights>
   </PropertyGroup>
 
   <ItemGroup>
@@ -52,17 +52,17 @@
     <PackageReference Include="Arcus.Messaging.Pumps.ServiceBus" Version="1.2.0" />
     <PackageReference Include="Arcus.Observability.Correlation" Version="2.5.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.5.0" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Filters" Version="2.5.0" Condition="'$(Serilog)' == 'true'" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="2.5.0" Condition="'$(Serilog)' == 'true'" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Filters" Version="2.5.0" Condition="'$(Serilog_AppInsights)' == 'true'" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="2.5.0" Condition="'$(Serilog_AppInsights)' == 'true'" />
     <PackageReference Include="Arcus.Security.Core" Version="1.7.0" />
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.7.0" />
     <PackageReference Include="Guard.NET" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Serilog" Version="2.11.0" Condition="'$(Serilog)' == 'true'" />
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="5.0.1" Condition="'$(Serilog)' == 'true'" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" Condition="'$(Serilog)' == 'true'" />
+    <PackageReference Include="Serilog" Version="2.11.0" Condition="'$(Serilog_AppInsights)' == 'true'" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="5.0.1" Condition="'$(Serilog_AppInsights)' == 'true'" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" Condition="'$(Serilog_AppInsights)' == 'true'" />
   </ItemGroup>
 
 </Project>

--- a/src/Arcus.Templates.ServiceBus.Queue/Program.cs
+++ b/src/Arcus.Templates.ServiceBus.Queue/Program.cs
@@ -5,7 +5,7 @@ using Arcus.Security.Core.Caching.Configuration;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-#if Serilog
+#if Serilog_AppInsights
 using Serilog;
 using Serilog.Configuration;
 using Serilog.Events;
@@ -16,14 +16,14 @@ namespace Arcus.Templates.ServiceBus.Queue
 {
     public class Program
     {
-#if Serilog
+#if Serilog_AppInsights
         #warning Make sure that the Azure Application Insights connection string key is available as a secret.
         private const string ApplicationInsightsConnectionStringKeyName = "APPLICATIONINSIGHTS_CONNECTION_STRING";
         
 #endif
         public static async Task<int> Main(string[] args)
         {
-#if Serilog
+#if Serilog_AppInsights
             Log.Logger = new LoggerConfiguration()
                 .MinimumLevel.Debug()
                 .WriteTo.Console()
@@ -72,7 +72,7 @@ namespace Arcus.Templates.ServiceBus.Queue
                            //#error Please provide a valid secret provider, for example Azure Key Vault: https://security.arcus-azure.net/features/secret-store/provider/key-vault
                            stores.AddAzureKeyVaultWithManagedIdentity("https://your-keyvault.vault.azure.net/", CacheConfiguration.Default);
                        })
-#if Serilog
+#if Serilog_AppInsights
                        .UseSerilog(Log.Logger)
 #endif
                        .ConfigureServices((hostContext, services) =>
@@ -83,7 +83,7 @@ namespace Arcus.Templates.ServiceBus.Queue
                            services.AddTcpHealthProbes("ARCUS_HEALTH_PORT");
                        });
         }
-#if Serilog
+#if Serilog_AppInsights
         
         private static async Task ConfigureSerilogAsync(IHost host)
         {

--- a/src/Arcus.Templates.ServiceBus.Topic/.template.config/template.json
+++ b/src/Arcus.Templates.ServiceBus.Topic/.template.config/template.json
@@ -69,7 +69,7 @@
       "defaultValue": "false",
       "description": "Exclude the Serilog logging infrastructure in the worker project"
     },
-    "Serilog": {
+    "Serilog_AppInsights": {
       "type": "computed",
       "value": "!(exclude-serilog)"
     }

--- a/src/Arcus.Templates.ServiceBus.Topic/Arcus.Templates.ServiceBus.Topic.csproj
+++ b/src/Arcus.Templates.ServiceBus.Topic/Arcus.Templates.ServiceBus.Topic.csproj
@@ -38,8 +38,8 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <DefineConstants>$(DefineConstants);Serilog</DefineConstants>
-    <Serilog>true</Serilog>
+    <DefineConstants>$(DefineConstants);Serilog_AppInsights</DefineConstants>
+    <Serilog_AppInsights>true</Serilog_AppInsights>
   </PropertyGroup>
 
   <ItemGroup>
@@ -52,17 +52,17 @@
     <PackageReference Include="Arcus.Messaging.Pumps.ServiceBus" Version="1.2.0" />
     <PackageReference Include="Arcus.Observability.Correlation" Version="2.5.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.5.0" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Filters" Version="2.5.0" Condition="'$(Serilog)' == 'true'" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="2.5.0" Condition="'$(Serilog)' == 'true'" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Filters" Version="2.5.0" Condition="'$(Serilog_AppInsights)' == 'true'" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="2.5.0" Condition="'$(Serilog_AppInsights)' == 'true'" />
     <PackageReference Include="Arcus.Security.Core" Version="1.7.0" />
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.7.0" />
     <PackageReference Include="Guard.NET" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Serilog" Version="2.11.0" Condition="'$(Serilog)' == 'true'" />
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="5.0.1" Condition="'$(Serilog)' == 'true'" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" Condition="'$(Serilog)' == 'true'" />
+    <PackageReference Include="Serilog" Version="2.11.0" Condition="'$(Serilog_AppInsights)' == 'true'" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="5.0.1" Condition="'$(Serilog_AppInsights)' == 'true'" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" Condition="'$(Serilog_AppInsights)' == 'true'" />
   </ItemGroup>
 
 </Project>

--- a/src/Arcus.Templates.ServiceBus.Topic/Program.cs
+++ b/src/Arcus.Templates.ServiceBus.Topic/Program.cs
@@ -5,7 +5,7 @@ using Arcus.Security.Core.Caching.Configuration;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-#if Serilog
+#if Serilog_AppInsights
 using Serilog;
 using Serilog.Configuration;
 using Serilog.Events;
@@ -16,14 +16,14 @@ namespace Arcus.Templates.ServiceBus.Topic
 {
     public class Program
     {
-#if Serilog
+#if Serilog_AppInsights
         #warning Make sure that the Azure Application Insights connection string key is available as a secret.
         private const string ApplicationInsightsConnectionStringKeyName = "APPLICATIONINSIGHTS_CONNECTION_STRING";
         
 #endif
         public static async Task<int> Main(string[] args)
         {
-#if Serilog
+#if Serilog_AppInsights
             Log.Logger = new LoggerConfiguration()
                 .MinimumLevel.Debug()
                 .WriteTo.Console()
@@ -71,7 +71,7 @@ namespace Arcus.Templates.ServiceBus.Topic
                            //#error Please provide a valid secret provider, for example Azure Key Vault: https://security.arcus-azure.net/features/secret-store/provider/key-vault
                            stores.AddAzureKeyVaultWithManagedIdentity("https://your-keyvault.vault.azure.net/", CacheConfiguration.Default);
                        })
-#if Serilog
+#if Serilog_AppInsights
                        .UseSerilog(Log.Logger)
 #endif
                        .ConfigureServices((hostContext, services) =>
@@ -82,7 +82,7 @@ namespace Arcus.Templates.ServiceBus.Topic
                            services.AddTcpHealthProbes("ARCUS_HEALTH_PORT");
                        });
         }
-#if Serilog
+#if Serilog_AppInsights
         
         private static async Task ConfigureSerilogAsync(IHost host)
         {

--- a/src/Arcus.Templates.WebApi/.template.config/template.json
+++ b/src/Arcus.Templates.WebApi/.template.config/template.json
@@ -168,7 +168,7 @@
       "type": "computed",
       "value": "(logging == \"Console\")"
     },
-    "Serilog": {
+    "Serilog_AppInsights": {
       "type": "computed",
       "value": "(logging == \"Serilog\")"
     }

--- a/src/Arcus.Templates.WebApi/.template.config/template.json
+++ b/src/Arcus.Templates.WebApi/.template.config/template.json
@@ -120,7 +120,7 @@
     },
     "AppSettings": {
       "type": "computed",
-      "value": "include-appsettings || CertificateAuth || Serilog || JwtAuth"
+      "value": "include-appsettings || CertificateAuth || Serilog_AppInsights || JwtAuth"
     },
     "include-appsettings": {
       "type": "parameter",

--- a/src/Arcus.Templates.WebApi/Arcus.Templates.WebApi.csproj
+++ b/src/Arcus.Templates.WebApi/Arcus.Templates.WebApi.csproj
@@ -40,13 +40,13 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <DefineConstants>$(DefineConstants);SharedAccessKeyAuth;CertificateAuth;Auth;Serilog;Console;OpenApi;Correlation</DefineConstants>
+    <DefineConstants>$(DefineConstants);SharedAccessKeyAuth;CertificateAuth;Auth;Serilog_AppInsights;Console;OpenApi;Correlation</DefineConstants>
     <SharedAccessKeyAuth>true</SharedAccessKeyAuth>
     <CertificateAuth>true</CertificateAuth>
     <JwtAuth>false</JwtAuth>
     <Auth>true</Auth>
     <Correlation>true</Correlation>
-    <Serilog>true</Serilog>
+    <Serilog_AppInsights>true</Serilog_AppInsights>
     <Console>true</Console>
     <OpenApi>true</OpenApi>
   </PropertyGroup>
@@ -67,8 +67,8 @@
     <PackageReference Include="Arcus.Observability.Correlation" Version="2.5.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.AspNetCore" Version="2.5.0" />
     <PackageReference Include="Arcus.Observability.Telemetry.Core" Version="2.5.0" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Filters" Version="2.5.0" Condition="'$(Serilog)' == 'true'" />
-    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="2.5.0" Condition="'$(Serilog)' == 'true'" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Filters" Version="2.5.0" Condition="'$(Serilog_AppInsights)' == 'true'" />
+    <PackageReference Include="Arcus.Observability.Telemetry.Serilog.Sinks.ApplicationInsights" Version="2.5.0" Condition="'$(Serilog_AppInsights)' == 'true'" />
     <PackageReference Include="Arcus.Security.Core" Version="1.7.0" />
     <PackageReference Include="Arcus.Security.Providers.AzureKeyVault" Version="1.7.0" />
     <PackageReference Include="Arcus.WebApi.Hosting" Version="1.6.1" />
@@ -77,7 +77,7 @@
     <PackageReference Include="Guard.NET" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.8" Condition="'$(JwtAuth)' == 'true'" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" Condition="'$(Serilog)' == 'true'" />
+    <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" Condition="'$(Serilog_AppInsights)' == 'true'" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" Condition="'$(OpenApi)' == 'true'" />
     <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="7.0.5" Condition="'$(OpenApi)' == 'true' and '$(Correlation)' == 'true'" />
   </ItemGroup>

--- a/src/Arcus.Templates.WebApi/Program.cs
+++ b/src/Arcus.Templates.WebApi/Program.cs
@@ -20,7 +20,7 @@ using Microsoft.Extensions.Hosting;
 #if Console
 using Microsoft.Extensions.Logging; 
 #endif
-#if Serilog
+#if Serilog_AppInsights
 using Serilog;
 using Serilog.Configuration;
 using Serilog.Extensions.Hosting;
@@ -49,7 +49,7 @@ namespace Arcus.Templates.WebApi
 {
     public class Program
     {
-#if Serilog
+#if Serilog_AppInsights
         #warning Make sure that the Azure Application Insights connection string key is available as a secret.
         private const string ApplicationInsightsConnectionStringKeyName = "APPLICATIONINSIGHTS_CONNECTION_STRING";
         
@@ -60,7 +60,7 @@ namespace Arcus.Templates.WebApi
 #endif
         public static async Task<int> Main(string[] args)
         {
-#if Serilog
+#if Serilog_AppInsights
             Log.Logger = new LoggerConfiguration()
                 .MinimumLevel.Debug()
                 .WriteTo.Console()
@@ -316,7 +316,7 @@ namespace Arcus.Templates.WebApi
                 //#error Please provide a valid secret provider, for example Azure Key Vault: https://security.arcus-azure.net/features/secret-store/provider/key-vault
                 stores.AddAzureKeyVaultWithManagedIdentity("https://your-keyvault.vault.azure.net/", CacheConfiguration.Default);
             });
-#if Serilog
+#if Serilog_AppInsights
             builder.Host.UseSerilog(Log.Logger);
 #endif
 #if Console
@@ -324,7 +324,7 @@ namespace Arcus.Templates.WebApi
 #endif
         }
 
-#if Serilog
+#if Serilog_AppInsights
         
         private static async Task ConfigureSerilogAsync(WebApplication app)
         {

--- a/src/Arcus.Templates.WebApi/appsettings.json
+++ b/src/Arcus.Templates.WebApi/appsettings.json
@@ -2,7 +2,7 @@
   //#if (CertificateAuth)
   "CertificateSubject": "<your-certificate-subject-name>",
   //#endif
-  //#if (Serilog)
+  //#if (Serilog_AppInsights)
   "APPLICATIONINSIGHTS_CONNECTION_STRING": "",
   "Serilog": {
     "MinimumLevel": {


### PR DESCRIPTION
Rename `Serilog` directive to `Serilog_AppInsights` directive to indicate that the Serilog configuration added to the project with the project option includes Azure Application Insights telemetry logging.

Closes #625