### PR TITLE
feature/add default http port

### DIFF
--- a/src/Arcus.Templates.WebApi/Program.cs
+++ b/src/Arcus.Templates.WebApi/Program.cs
@@ -304,7 +304,11 @@ namespace Arcus.Templates.WebApi
 #endif
         private static void ConfigureHost(WebApplicationBuilder builder, IConfiguration configuration)
         {
-            string httpEndpointUrl = "http://+:" + configuration.GetValue("ARCUS_HTTP_PORT", 5000);
+#if AppSettings
+            string httpEndpointUrl = "http://+:" + configuration.GetValue<int>("ARCUS_HTTP_PORT"); 
+#else
+            string httpEndpointUrl = "http://+:" + configuration.GetValue("ARCUS_HTTP_PORT", 5000); 
+#endif
             builder.WebHost.ConfigureKestrel(options => options.AddServerHeader = false)
                            .UseUrls(httpEndpointUrl);
             

--- a/src/Arcus.Templates.WebApi/Program.cs
+++ b/src/Arcus.Templates.WebApi/Program.cs
@@ -304,7 +304,7 @@ namespace Arcus.Templates.WebApi
 #endif
         private static void ConfigureHost(WebApplicationBuilder builder, IConfiguration configuration)
         {
-            string httpEndpointUrl = "http://+:" + configuration["ARCUS_HTTP_PORT"];
+            string httpEndpointUrl = "http://+:" + configuration.GetValue("ARCUS_HTTP_PORT", 5000);
             builder.WebHost.ConfigureKestrel(options => options.AddServerHeader = false)
                            .UseUrls(httpEndpointUrl);
             

--- a/src/Arcus.Templates.WebApi/appsettings.json
+++ b/src/Arcus.Templates.WebApi/appsettings.json
@@ -16,5 +16,5 @@
     "Audience": "<your-audience>"
   },
   //#endif
-  "MyConfigKey": "MyConfigValue"
+  "ARCUS_HTTP_PORT": 5000
 }


### PR DESCRIPTION
Add default HTTP port to Web API project template in both with and without `appsettings.json`:
- with: provide default HTTP port in `appsettings.json`
- without: provide default HTTP port within code, if none is provided

Closes #683