### PR TITLE
chore: remove installation details from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,49 +6,7 @@
 
 ![Arcus](https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png)
 
-# Installation
-
-## Web API Template
-We provide a template to build Web APIs. ([docs](https://templates.arcus-azure.net/features/web-api-template))
-
-First, install the template:
-```shell
-> dotnet new --install Arcus.Templates.WebApi
-```
-
-When installed, the template can be created with shortname: `arcus-webapi`:
-```shell
-> dotnet new arcus-webapi --name Arcus.Demo.WebAPI
-```
-
-## Azure Service Bus Queue Worker Template
-We provide a template to build worker projects with a Azure Service Bus message pump. ([docs](https://templates.arcus-azure.net/features/servicebus-queue-worker-template))
-
-First, install the template:
-```shell
-> dotnet new --install Arcus.Templates.SerivceBus.Queue
-```
-
-When installed, the template can be created with shortname: `arcus-servicebus-queue`:
-```shell
-> dotnet new arcus-servicebus-queue --name Arcus.Demo.ServiceBus.Queue
-```
-
-## Azure Service Bus Topic Worker Template
-We provide a template to build worker projects with a Azure Service Bus message pump. ([docs](https://templates.arcus-azure.net/features/servicebus-topic-worker-template))
-
-First, install the template:
-```shell
-> dotnet new --install Arcus.Templates.ServiceBus.Topic
-```
-
-When installed, the template can be created with shortname: `arcus-servicebus-topic`:
-```shell
-> dotnet new arcus-servicebus-topic --name Arcus.Demo.ServiceBus.Topic
-```
-
 # Documentation
-
 All documentation can be found on [here](https://templates.arcus-azure.net/).
 
 # Customers


### PR DESCRIPTION
It is hard to maintain and keep up to date and it does not provide enough added-value as it is a duplication of the documentation, so removed the installation details from the `README.md` file.

Closes #640 