### PR TITLE
chore: use `local.settings.json` in Azure Functions HTTP trigger project template

### DIFF
--- a/src/Arcus.Templates.AzureFunctions.Http/local.settings.json
+++ b/src/Arcus.Templates.AzureFunctions.Http/local.settings.json
@@ -1,0 +1,10 @@
+{
+    "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "",
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet",
+    //#if (Serilog_AppInsights)
+    "APPLICATIONINSIGHTS_CONNECTION_STRING": ""
+    //#endif
+  }
+}

--- a/src/Arcus.Templates.AzureFunctions.Http/local.settings.json
+++ b/src/Arcus.Templates.AzureFunctions.Http/local.settings.json
@@ -1,14 +1,14 @@
 {
     "IsEncrypted": false,
   "Values": {
-    "AzureWebJobsStorage": "",
     //#if(Isolated)
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
     //#else
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
     //#endif
     //#if (Serilog_AppInsights)
-    "APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=<key>"
+    "APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=<key>",
     //#endif
+    "AzureWebJobsStorage": ""
   }
 }

--- a/src/Arcus.Templates.AzureFunctions.Http/local.settings.json
+++ b/src/Arcus.Templates.AzureFunctions.Http/local.settings.json
@@ -2,9 +2,13 @@
     "IsEncrypted": false,
   "Values": {
     "AzureWebJobsStorage": "",
+    //#if(Isolated)
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+    //#else
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
+    //#endif
     //#if (Serilog_AppInsights)
-    "APPLICATIONINSIGHTS_CONNECTION_STRING": ""
+    "APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=<key>"
     //#endif
   }
 }

--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/AzureFunctionsProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/AzureFunctionsProject.cs
@@ -117,7 +117,6 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions
             };
             Logger.WriteLine("> {0} {1}", processInfo.FileName, processInfo.Arguments);
 
-            //Environment.SetEnvironmentVariable(ApplicationInsightsConnectionStringKeyVariable, $"InstrumentationKey={ApplicationInsightsConfig.InstrumentationKey}");
             return processInfo;
         }
 
@@ -163,15 +162,6 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions
                     "The test project created from the Azure Functions project template doesn't seem to be running, "
                     + "please check any build or runtime errors that could occur when the test project was created");
             }
-        }
-
-        /// <summary>
-        /// Performs additional application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
-        /// </summary>
-        /// <param name="disposing">The flag indicating whether or not the additional tasks should be disposed.</param>
-        protected override void Disposing(bool disposing)
-        {
-            Environment.SetEnvironmentVariable(ApplicationInsightsConnectionStringKeyVariable, null);
         }
     }
 }

--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/AzureFunctionsProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/AzureFunctionsProject.cs
@@ -117,7 +117,7 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions
             };
             Logger.WriteLine("> {0} {1}", processInfo.FileName, processInfo.Arguments);
 
-            Environment.SetEnvironmentVariable(ApplicationInsightsConnectionStringKeyVariable, $"InstrumentationKey={ApplicationInsightsConfig.InstrumentationKey}");
+            //Environment.SetEnvironmentVariable(ApplicationInsightsConnectionStringKeyVariable, $"InstrumentationKey={ApplicationInsightsConfig.InstrumentationKey}");
             return processInfo;
         }
 

--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/Databricks/JobMetrics/AzureFunctionsDatabricksProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/Databricks/JobMetrics/AzureFunctionsDatabricksProject.cs
@@ -131,6 +131,9 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions.Databricks.JobMetrics
             Environment.SetEnvironmentVariable(ApplicationInsightsMetricNameVariable, ApplicationInsightsConfig.MetricName);
             Environment.SetEnvironmentVariable(DatabricksUrlVariable, AzureFunctionDatabricksConfig.BaseUrl);
 
+            ApplicationInsightsConfig appInsightsConfig = Configuration.GetApplicationInsightsConfig();
+            Environment.SetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING", $"InstrumentationKey={appInsightsConfig.InstrumentationKey}");
+
             return startInfo;
         }
 
@@ -143,6 +146,7 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions.Databricks.JobMetrics
             base.Disposing(disposing);
             Environment.SetEnvironmentVariable(ApplicationInsightsMetricNameVariable, null);
             Environment.SetEnvironmentVariable(DatabricksUrlVariable, null);
+            Environment.SetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING", null);
         }
     }
 }

--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/EventHubs/AzureFunctionsEventHubsProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/EventHubs/AzureFunctionsEventHubsProject.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Arcus.Templates.Tests.Integration.AzureFunctions.Databricks.JobMetrics.Configuration;
 using Arcus.Templates.Tests.Integration.Fixture;
 using Arcus.Templates.Tests.Integration.Worker.Configuration;
 using Arcus.Templates.Tests.Integration.Worker.EventHubs;
@@ -132,6 +133,9 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions.EventHubs
             Environment.SetEnvironmentVariable("EVENTGRID_TOPIC_URI", eventGridConfig.TopicUri);
             Environment.SetEnvironmentVariable("EVENTGRID_AUTH_KEY", eventGridConfig.AuthenticationKey);
 
+            ApplicationInsightsConfig appInsightsConfig = Configuration.GetApplicationInsightsConfig();
+            Environment.SetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING", $"InstrumentationKey={appInsightsConfig.InstrumentationKey}");
+
             Run(Configuration.BuildConfiguration, TargetFramework.Net6_0);
             await MessagePump.StartAsync();
         }
@@ -145,6 +149,7 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions.EventHubs
             Environment.SetEnvironmentVariable("EventHubsConnectionString", null);
             Environment.SetEnvironmentVariable("EVENTGRID_TOPIC_URI", null);
             Environment.SetEnvironmentVariable("EVENTGRID_AUTH_KEY", null);
+            Environment.SetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING", null);
 
             Dispose();
             await MessagePump.DisposeAsync();

--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/Http/AzureFunctionsHttpProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/Http/AzureFunctionsHttpProject.cs
@@ -12,6 +12,7 @@ using Flurl;
 using GuardNet;
 using Polly.Retry;
 using Polly;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Arcus.Templates.Tests.Integration.AzureFunctions.Http
@@ -208,8 +209,18 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions.Http
             
             var project = new AzureFunctionsHttpProject(configuration, options, outputWriter);
             project.CreateNewProject(options);
-            project.AddLocalSettings(options.FunctionsWorker);
+            project.UpdateFileInProject(
+                "local.settings.json",
+                contents =>
+                {
+                    var json = JsonObject.Parse(contents);
+                    json["Host"] = new JsonObject(new[]
+                    {
+                        new KeyValuePair<string, JsonNode>("LocalHttpPort", project.RootEndpoint.Port)
+                    });
 
+                    return json.ToString();
+                });
             project.UpdateFileInProject(project.RuntimeFileName, contents => project.RemovesUserErrorsFromContents(contents));
 
             return project;

--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/Http/Health/HealthChecksTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/Http/Health/HealthChecksTests.cs
@@ -41,7 +41,6 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions.Http.Health
             
             using (var project = await AzureFunctionsHttpProject.StartNewAsync(_config, options, _outputWriter))
             {
-                project.TearDownOptions = TearDownOptions.KeepProjectDirectory;
                 // Act
                 using (HttpResponseMessage response = await project.Health.GetAsync())
                 {

--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/Http/Health/HealthChecksTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/Http/Health/HealthChecksTests.cs
@@ -41,6 +41,7 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions.Http.Health
             
             using (var project = await AzureFunctionsHttpProject.StartNewAsync(_config, options, _outputWriter))
             {
+                project.TearDownOptions = TearDownOptions.KeepProjectDirectory;
                 // Act
                 using (HttpResponseMessage response = await project.Health.GetAsync())
                 {


### PR DESCRIPTION
Use `local.settings.json` to set Azure Application Insights connection string so that the Azure Functions HTTP trigger project created from the template can be run directly.

Closes #746