### PR TITLE
chore: don't use special chars in `local.settings.json`

### DIFF
--- a/src/Arcus.Templates.AzureFunctions.Http/local.settings.json
+++ b/src/Arcus.Templates.AzureFunctions.Http/local.settings.json
@@ -7,7 +7,7 @@
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
     //#endif
     //#if (Serilog_AppInsights)
-    "APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=<key>",
+    "APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=yourKey",
     //#endif
     "AzureWebJobsStorage": ""
   }


### PR DESCRIPTION
Special characters are getting escaped, which makes it rather strange-looking.
Better to avoid special characters, here.