### PR TITLE
fix: do not exclude launchsettings.json on webApi template

### DIFF
--- a/src/Arcus.Templates.WebApi/Arcus.Templates.WebApi.csproj
+++ b/src/Arcus.Templates.WebApi/Arcus.Templates.WebApi.csproj
@@ -35,7 +35,7 @@
   <!--#if (AuthoringMode)-->
 
   <ItemGroup>
-    <Content Include="**\*" Exclude="**\bin\**\*;**\obj\**\*;**\.vs\**\*;**\launchSettings.json" />
+    <Content Include="**\*" Exclude="**\bin\**\*;**\obj\**\*;**\.vs\**\*" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
launchsettings.json was not added to the webapi project by this.

Relates to #764 