### PR TITLE
chore: streamline launchsettings in project templates (❗)

### DIFF
--- a/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/Arcus.Templates.AzureFunctions.Databricks.JobMetrics.csproj
+++ b/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/Arcus.Templates.AzureFunctions.Databricks.JobMetrics.csproj
@@ -32,7 +32,7 @@
 
   <!--#if (AuthoringMode)-->
   <ItemGroup>
-    <Content Include="**\*" Exclude="**\bin\**\*;**\obj\**\*;**\.vs\**\*;**\launchSettings.json" />
+    <Content Include="**\*" Exclude="**\bin\**\*;**\obj\**\*;**\.vs\**\*" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -42,9 +42,17 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="Properties\launchSettings.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="Properties\launchSettings.json" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
     <None Include="..\..\LICENSE" Pack="true" PackagePath="\" />
-    <None Include="..\..\docs\static\img\icon.png" Pack="true" PackagePath="\"/>
+    <None Include="..\..\docs\static\img\icon.png" Pack="true" PackagePath="\" />
   </ItemGroup>
   <!--#endif-->
 
@@ -69,6 +77,6 @@
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions" Version="4.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" Condition="'$(Serilog_AppInsights)' == 'true'" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" Condition="'$(Serilog_AppInsights)' == 'true'"  />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" Condition="'$(Serilog_AppInsights)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/Arcus.Templates.AzureFunctions.Databricks.JobMetrics.csproj
+++ b/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/Arcus.Templates.AzureFunctions.Databricks.JobMetrics.csproj
@@ -42,14 +42,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="Properties\launchSettings.json" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="Properties\launchSettings.json" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
     <None Include="..\..\LICENSE" Pack="true" PackagePath="\" />
     <None Include="..\..\docs\static\img\icon.png" Pack="true" PackagePath="\" />

--- a/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/Properties/launchSettings.json
+++ b/src/Arcus.Templates.AzureFunctions.Databricks.JobMetrics/Properties/launchSettings.json
@@ -1,6 +1,6 @@
 {
   "profiles": {
-    "Arcus.Templates.ServiceBus.Queue": {
+    "Arcus.Templates.AzureFunctions.Databricks.JobMetrics": {
       "commandName": "Project"
     },
     "Docker": {

--- a/src/Arcus.Templates.AzureFunctions.EventHubs/Arcus.Templates.AzureFunctions.EventHubs.csproj
+++ b/src/Arcus.Templates.AzureFunctions.EventHubs/Arcus.Templates.AzureFunctions.EventHubs.csproj
@@ -30,7 +30,7 @@
   </PropertyGroup>
   <!--#if (AuthoringMode)-->
   <ItemGroup>
-    <Content Include="**\*" Exclude="**\bin\**\*;**\obj\**\*;**\.vs\**\*;**\launchSettings.json" />
+    <Content Include="**\*" Exclude="**\bin\**\*;**\obj\**\*;**\.vs\**\*" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -42,9 +42,17 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="Properties\launchSettings.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="Properties\launchSettings.json" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
     <None Include="..\..\LICENSE" Pack="true" PackagePath="\" />
-    <None Include="..\..\docs\static\img\icon.png" Pack="true" PackagePath="\"/>
+    <None Include="..\..\docs\static\img\icon.png" Pack="true" PackagePath="\" />
   </ItemGroup>
   <!--#endif-->
 

--- a/src/Arcus.Templates.AzureFunctions.EventHubs/Arcus.Templates.AzureFunctions.EventHubs.csproj
+++ b/src/Arcus.Templates.AzureFunctions.EventHubs/Arcus.Templates.AzureFunctions.EventHubs.csproj
@@ -42,14 +42,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="Properties\launchSettings.json" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="Properties\launchSettings.json" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Include="..\..\README.md" Pack="true" PackagePath="\" />
     <None Include="..\..\LICENSE" Pack="true" PackagePath="\" />
     <None Include="..\..\docs\static\img\icon.png" Pack="true" PackagePath="\" />

--- a/src/Arcus.Templates.AzureFunctions.EventHubs/Properties/launchSettings.json
+++ b/src/Arcus.Templates.AzureFunctions.EventHubs/Properties/launchSettings.json
@@ -1,6 +1,6 @@
 {
   "profiles": {
-    "Arcus.Templates.ServiceBus.Queue": {
+    "Arcus.Templates.AzureFunctions.EventHubs": {
       "commandName": "Project"
     },
     "Docker": {

--- a/src/Arcus.Templates.AzureFunctions.Http/Arcus.Templates.AzureFunctions.Http.csproj
+++ b/src/Arcus.Templates.AzureFunctions.Http/Arcus.Templates.AzureFunctions.Http.csproj
@@ -33,7 +33,7 @@
 
   <!--#if (AuthoringMode)-->
   <ItemGroup>
-    <Content Include="**\*" Exclude="**\bin\**\*;**\obj\**\*;**\.vs\**\*;**\launchSettings.json" />
+    <Content Include="**\*" Exclude="**\bin\**\*;**\obj\**\*;**\.vs\**\*" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Arcus.Templates.AzureFunctions.Http/Properties/launchSettings.json
+++ b/src/Arcus.Templates.AzureFunctions.Http/Properties/launchSettings.json
@@ -1,6 +1,6 @@
 {
   "profiles": {
-    "Arcus.Templates.ServiceBus.Queue": {
+    "Arcus.Templates.AzureFunctions.Http": {
       "commandName": "Project"
     },
     "Docker": {

--- a/src/Arcus.Templates.AzureFunctions.ServiceBus.Queue/Arcus.Templates.AzureFunctions.ServiceBus.Queue.csproj
+++ b/src/Arcus.Templates.AzureFunctions.ServiceBus.Queue/Arcus.Templates.AzureFunctions.ServiceBus.Queue.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
   <!--#if (AuthoringMode)-->
   <ItemGroup>
-    <Content Include="**\*" Exclude="**\bin\**\*;**\obj\**\*;**\.vs\**\*;**\launchSettings.json" />
+    <Content Include="**\*" Exclude="**\bin\**\*;**\obj\**\*;**\.vs\**\*" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Arcus.Templates.AzureFunctions.ServiceBus.Queue/Properties/launchSettings.json
+++ b/src/Arcus.Templates.AzureFunctions.ServiceBus.Queue/Properties/launchSettings.json
@@ -1,6 +1,6 @@
 {
   "profiles": {
-    "Arcus.Templates.ServiceBus.Queue": {
+    "Arcus.Templates.AzureFunctions.ServiceBus.Queue": {
       "commandName": "Project"
     },
     "Docker": {

--- a/src/Arcus.Templates.AzureFunctions.ServiceBus.Topic/Arcus.Templates.AzureFunctions.ServiceBus.Topic.csproj
+++ b/src/Arcus.Templates.AzureFunctions.ServiceBus.Topic/Arcus.Templates.AzureFunctions.ServiceBus.Topic.csproj
@@ -30,7 +30,7 @@
   </PropertyGroup>
   <!--#if (AuthoringMode)-->
   <ItemGroup>
-    <Content Include="**\*" Exclude="**\bin\**\*;**\obj\**\*;**\.vs\**\*;**\launchSettings.json" />
+    <Content Include="**\*" Exclude="**\bin\**\*;**\obj\**\*;**\.vs\**\*" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Arcus.Templates.AzureFunctions.ServiceBus.Topic/Properties/launchSettings.json
+++ b/src/Arcus.Templates.AzureFunctions.ServiceBus.Topic/Properties/launchSettings.json
@@ -1,6 +1,6 @@
 {
   "profiles": {
-    "Arcus.Templates.ServiceBus.Queue": {
+    "Arcus.Templates.AzureFunctions.ServiceBus.Topic": {
       "commandName": "Project"
     },
     "Docker": {

--- a/src/Arcus.Templates.EventHubs/Arcus.Templates.EventHubs.csproj
+++ b/src/Arcus.Templates.EventHubs/Arcus.Templates.EventHubs.csproj
@@ -33,7 +33,7 @@
 
   <!--#if (AuthoringMode)-->
   <ItemGroup>
-    <Content Include="**\*" Exclude="**\bin\**\*;**\obj\**\*;**\.vs\**\*;**\launchSettings.json" />
+    <Content Include="**\*" Exclude="**\bin\**\*;**\obj\**\*;**\.vs\**\*" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Arcus.Templates.EventHubs/Properties/launchSettings.json
+++ b/src/Arcus.Templates.EventHubs/Properties/launchSettings.json
@@ -1,6 +1,6 @@
 {
   "profiles": {
-    "Arcus.Templates.ServiceBus.Queue": {
+    "Arcus.Templates.EventHubs": {
       "commandName": "Project"
     },
     "Docker": {

--- a/src/Arcus.Templates.ServiceBus.Queue/Arcus.Templates.ServiceBus.Queue.csproj
+++ b/src/Arcus.Templates.ServiceBus.Queue/Arcus.Templates.ServiceBus.Queue.csproj
@@ -33,7 +33,7 @@
 
   <!--#if (AuthoringMode)-->
   <ItemGroup>
-    <Content Include="**\*" Exclude="**\bin\**\*;**\obj\**\*;**\.vs\**\*;**\launchSettings.json" />
+    <Content Include="**\*" Exclude="**\bin\**\*;**\obj\**\*;**\.vs\**\*" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Arcus.Templates.ServiceBus.Topic/Arcus.Templates.ServiceBus.Topic.csproj
+++ b/src/Arcus.Templates.ServiceBus.Topic/Arcus.Templates.ServiceBus.Topic.csproj
@@ -33,7 +33,7 @@
 
   <!--#if (AuthoringMode)-->
   <ItemGroup>
-    <Content Include="**\*" Exclude="**\bin\**\*;**\obj\**\*;**\.vs\**\*;**\launchSettings.json" />
+    <Content Include="**\*" Exclude="**\bin\**\*;**\obj\**\*;**\.vs\**\*" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Arcus.Templates.ServiceBus.Topic/Properties/launchSettings.json
+++ b/src/Arcus.Templates.ServiceBus.Topic/Properties/launchSettings.json
@@ -1,6 +1,6 @@
 {
   "profiles": {
-    "Arcus.Templates.ServiceBus.Queue": {
+    "Arcus.Templates.ServiceBus.Topic": {
       "commandName": "Project"
     },
     "Docker": {

--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/Databricks/JobMetrics/AzureFunctionsDatabricksProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/Databricks/JobMetrics/AzureFunctionsDatabricksProject.cs
@@ -88,8 +88,24 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions.Databricks.JobMetrics
             return project;
         }
 
-        private static AzureFunctionsDatabricksProject CreateNew(TestConfig configuration, AzureFunctionsDatabricksProjectOptions options, ITestOutputHelper outputWriter)
+        /// <summary>
+        /// Creates a project from the Azure Functions Databricks Job Metrics project template.
+        /// </summary>
+        /// <param name="configuration">The configuration to control the hosting of the to-be-created project.</param>
+        /// <param name="options">The additional user project options to change the project contents and functionality.</param>
+        /// <param name="outputWriter">The output logger to add telemetry information during the creation process.</param>
+        /// <returns>
+        ///     A Azure Functions Databricks Job Metrics project with a full set of endpoint services to interact with the Azure Function.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when the <paramref name="configuration"/>, <paramref name="options"/>, or <paramref name="outputWriter"/> is <c>null</c>.
+        /// </exception>
+        public static AzureFunctionsDatabricksProject CreateNew(TestConfig configuration, AzureFunctionsDatabricksProjectOptions options, ITestOutputHelper outputWriter)
         {
+            Guard.NotNull(configuration, nameof(configuration), "Requires a test configuration instance to retrieve integration test configuration values to interact with Azure Databricks");
+            Guard.NotNull(options, nameof(options), "Requires a project options to change the project contents and functionality");
+            Guard.NotNull(outputWriter, nameof(outputWriter), "Requires a logging instance to write diagnostic information during the creation process");
+
             var project = new AzureFunctionsDatabricksProject(configuration, options, outputWriter);
             project.CreateNewProject(options);
             project.AddDatabricksSecurityToken(project.AzureFunctionDatabricksConfig.SecurityToken);

--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/Databricks/JobMetrics/Configuration/LaunchSettingsTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/Databricks/JobMetrics/Configuration/LaunchSettingsTests.cs
@@ -1,0 +1,39 @@
+﻿using System.IO;
+using Arcus.Templates.Tests.Integration.Fixture;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Arcus.Templates.Tests.Integration.AzureFunctions.Databricks.JobMetrics.Configuration
+{
+    [Trait("Category", TestTraits.Integration)]
+    public class LaunchSettingsTests
+    {
+        private readonly ITestOutputHelper _outputWriter;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LaunchSettingsTests" /> class.
+        /// </summary>
+        public LaunchSettingsTests(ITestOutputHelper outputWriter)
+        {
+            _outputWriter = outputWriter;
+        }
+
+        [Fact]
+        public void DatabricksJobMetricsTrigger_WithDefault_ConfiguresLaunchSettings()
+        {
+            // Arrange
+            var config = TestConfig.Create();
+            var options = new AzureFunctionsDatabricksProjectOptions();
+
+            // Act
+            using (var project = AzureFunctionsDatabricksProject.CreateNew(config, options, _outputWriter))
+            {
+                // Assert
+                string relativePath = Path.Combine("Properties", "launchSettings.json");
+                string json = project.GetFileContentsInProject(relativePath);
+                Assert.Contains(TemplateProject.ProjectName, json);
+                Assert.Contains("Docker", json);
+            }
+        }
+    }
+}

--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/EventHubs/AzureFunctionsEventHubsProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/EventHubs/AzureFunctionsEventHubsProject.cs
@@ -75,11 +75,27 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions.EventHubs
             return project;
         }
 
-        private static AzureFunctionsEventHubsProject CreateNew(
+        /// <summary>
+        /// Creates a project from the Azure Functions EventHubs project template.
+        /// </summary>
+        /// <param name="options">The additional project options to pass along to the project creation command.</param>
+        /// <param name="configuration">The collection of configuration values to correctly initialize the resulting project with secret values.</param>
+        /// <param name="outputWriter">The output logger to add telemetry information during the creation and startup process.</param>
+        /// <returns>
+        ///     An Azure Functions EventHubs project with a set of services to interact with the project.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when the <paramref name="options"/>, the <paramref name="configuration"/>, or the <paramref name="outputWriter"/> is <c>null</c>.
+        /// </exception>
+        public static AzureFunctionsEventHubsProject CreateNew(
             TestConfig configuration,
             AzureFunctionsEventHubsProjectOptions options,
             ITestOutputHelper outputWriter)
         {
+            Guard.NotNull(options, nameof(options), "Requires a set of project options to pass along to the project creation command");
+            Guard.NotNull(configuration, nameof(configuration), "Requires a configuration instance to retrieve the configuration values to pass along to the to-be-created project");
+            Guard.NotNull(outputWriter, nameof(outputWriter), "Requires a test logger to write diagnostic information during the creation process");
+
             EventHubsConfig eventHubsConfig = configuration.GetEventHubsConfig();
             var project = new AzureFunctionsEventHubsProject(configuration, options, outputWriter);
 

--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/EventHubs/Configuration/LaunchSettingsTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/EventHubs/Configuration/LaunchSettingsTests.cs
@@ -1,0 +1,39 @@
+﻿using System.IO;
+using Arcus.Templates.Tests.Integration.Fixture;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Arcus.Templates.Tests.Integration.AzureFunctions.EventHubs.Configuration
+{
+    [Trait("Category", TestTraits.Integration)]
+    public class LaunchSettingsTests
+    {
+        private readonly ITestOutputHelper _outputWriter;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LaunchSettingsTests" /> class.
+        /// </summary>
+        public LaunchSettingsTests(ITestOutputHelper outputWriter)
+        {
+            _outputWriter = outputWriter;
+        }
+
+        [Fact]
+        public void EventHubsTrigger_WithDefault_ConfiguresLaunchSettings()
+        {
+            // Arrange
+            var config = TestConfig.Create();
+            var options = new AzureFunctionsEventHubsProjectOptions();
+
+            // Act
+            using (var project = AzureFunctionsEventHubsProject.CreateNew(config, options, _outputWriter))
+            {
+                // Assert
+                string relativePath = Path.Combine("Properties", "launchSettings.json");
+                string json = project.GetFileContentsInProject(relativePath);
+                Assert.Contains(TemplateProject.ProjectName, json);
+                Assert.Contains("Docker", json);
+            }
+        }
+    }
+}

--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/Http/Configuration/LaunchSettingsTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/Http/Configuration/LaunchSettingsTests.cs
@@ -1,0 +1,38 @@
+﻿using System.IO;
+using Arcus.Templates.Tests.Integration.Fixture;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Arcus.Templates.Tests.Integration.AzureFunctions.Http.Configuration
+{
+    [Trait("Category", TestTraits.Integration)]
+    public class LaunchSettingsTests
+    {
+        private readonly ITestOutputHelper _outputWriter;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LaunchSettingsTests" /> class.
+        /// </summary>
+        public LaunchSettingsTests(ITestOutputHelper outputWriter)
+        {
+            _outputWriter = outputWriter;
+        }
+
+        [Fact]
+        public void HttpTrigger_WithDefault_ConfiguresLaunchSettings()
+        {
+            // Arrange
+            var config = TestConfig.Create();
+
+            // Act
+            using (var project = AzureFunctionsHttpProject.CreateNew(config, _outputWriter))
+            {
+                // Assert
+                string relativePath = Path.Combine("Properties", "launchSettings.json");
+                string json = project.GetFileContentsInProject(relativePath);
+                Assert.Contains(TemplateProject.ProjectName, json);
+                Assert.Contains("Docker", json);
+            }
+        }
+    }
+}

--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/ServiceBus/AzureFunctionsServiceBusProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/ServiceBus/AzureFunctionsServiceBusProject.cs
@@ -56,7 +56,7 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions.ServiceBus
         /// <param name="configuration">The collection of configuration values to correctly initialize the resulting project with secret values.</param>
         /// <param name="outputWriter">The output logger to add telemetry information during the creation and startup process.</param>
         /// <returns>
-        ///     An Azure Functions Service Bus Topic project with a set of services to interact with the worker.
+        ///     An Azure Functions Service Bus project with a set of services to interact with the worker.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         ///     Thrown when the <paramref name="configuration"/>, or the <paramref name="outputWriter"/> is <c>null</c>.
@@ -80,7 +80,7 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions.ServiceBus
         /// <param name="configuration">The collection of configuration values to correctly initialize the resulting project with secret values.</param>
         /// <param name="outputWriter">The output logger to add telemetry information during the creation and startup process.</param>
         /// <returns>
-        ///     An Azure Functions Service Bus Topic project with a set of services to interact with the project.
+        ///     An Azure Functions Service Bus project with a set of services to interact with the project.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         ///     Thrown when the <paramref name="options"/>, the <paramref name="configuration"/>, or the <paramref name="outputWriter"/> is <c>null</c>.
@@ -101,12 +101,29 @@ namespace Arcus.Templates.Tests.Integration.AzureFunctions.ServiceBus
             return project;
         }
 
-        private static AzureFunctionsServiceBusProject CreateNew(
+        /// <summary>
+        /// Creates a new project from the Azure Functions Service Bus project template.
+        /// </summary>
+        /// <param name="entityType">The type of the Azure Service Bus entity, to control the used project template.</param>
+        /// <param name="options">The additional project options to pass along to the project creation command.</param>
+        /// <param name="configuration">The collection of configuration values to correctly initialize the resulting project with secret values.</param>
+        /// <param name="outputWriter">The output logger to add telemetry information during the creation process.</param>
+        /// <returns>
+        ///     An Azure Functions Service Bus project with a set of services to interact with the project.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when the <paramref name="options"/>, the <paramref name="configuration"/>, or the <paramref name="outputWriter"/> is <c>null</c>.
+        /// </exception>
+        public static AzureFunctionsServiceBusProject CreateNew(
             ServiceBusEntityType entityType, 
             AzureFunctionsServiceBusProjectOptions options, 
             TestConfig configuration, 
             ITestOutputHelper outputWriter)
         {
+            Guard.NotNull(options, nameof(options), "Requires a set of project options to pass along to the project creation command");
+            Guard.NotNull(configuration, nameof(configuration), "Requires a configuration instance to retrieve the configuration values to pass along to the to-be-created project");
+            Guard.NotNull(outputWriter, nameof(outputWriter), "Requires a test logger to write diagnostic information during the creation process");
+
             var project = new AzureFunctionsServiceBusProject(entityType, configuration, options, outputWriter);
             project.CreateNewProject(options);
             project.AddOrderMessageHandlerImplementation();

--- a/src/Arcus.Templates.Tests.Integration/AzureFunctions/ServiceBus/Configuration/LaunchSettingsTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/AzureFunctions/ServiceBus/Configuration/LaunchSettingsTests.cs
@@ -1,0 +1,42 @@
+﻿using System.IO;
+using Arcus.Templates.Tests.Integration.Fixture;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Arcus.Templates.Tests.Integration.AzureFunctions.ServiceBus.Configuration
+{
+    [Trait("Category", TestTraits.Integration)]
+    public class LaunchSettingsTests
+    {
+        private readonly ITestOutputHelper _outputWriter;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LaunchSettingsTests" /> class.
+        /// </summary>
+        public LaunchSettingsTests(ITestOutputHelper outputWriter)
+        {
+            _outputWriter = outputWriter;
+        }
+
+        [Theory]
+        [InlineData(ServiceBusEntityType.Topic)]
+        [InlineData(ServiceBusEntityType.Queue)]
+        public void ServiceBusTriggerTemplate_WithDefault_ConfiguresLaunchSettings(ServiceBusEntityType entityType)
+        {
+            // Arrange
+            var options = new AzureFunctionsServiceBusProjectOptions(entityType);
+            var config = TestConfig.Create();
+
+            // Act
+            using (var project = AzureFunctionsServiceBusProject.CreateNew(entityType, options, config, _outputWriter))
+            {
+                // Assert
+                string relativePath = Path.Combine("Properties", "launchSettings.json");
+                string json = project.GetFileContentsInProject(relativePath);
+                Assert.Contains(TemplateProject.ProjectName, json);
+                Assert.Contains("Docker", json);
+            }
+        }
+    }
+}

--- a/src/Arcus.Templates.Tests.Integration/WebApi/Configuration/LaunchSettingsTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/WebApi/Configuration/LaunchSettingsTests.cs
@@ -1,0 +1,54 @@
+﻿using System.IO;
+using Arcus.Templates.Tests.Integration.Fixture;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Arcus.Templates.Tests.Integration.WebApi.Configuration
+{
+    [Trait("Category", TestTraits.Integration)]
+    public class LaunchSettingsTests
+    {
+        private readonly ITestOutputHelper _outputWriter;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LaunchSettingsTests" /> class.
+        /// </summary>
+        public LaunchSettingsTests(ITestOutputHelper outputWriter)
+        {
+            _outputWriter = outputWriter;
+        }
+
+        [Fact]
+        public void WebApiTemplate_WithDefault_ConfiguresLaunchSettings()
+        {
+            // Act
+            using (var project = WebApiProject.CreateNew(_outputWriter))
+            {
+                // Assert
+                string relativePath = Path.Combine("Properties", "launchSettings.json");
+                string json = project.GetFileContentsInProject(relativePath);
+                Assert.Contains(TemplateProject.ProjectName, json);
+                Assert.Contains("Docker", json);
+                Assert.Contains("api/docs", json);
+            }
+        }
+
+        [Fact]
+        public void WebApiTemplate_WithoutOpenApi_ConfiguresLaunchSettings()
+        {
+            // Act
+            var options = new WebApiProjectOptions().WithExcludeOpenApiDocs();
+
+            // Act
+            using (var project = WebApiProject.CreateNew(options, _outputWriter))
+            {
+                // Assert
+                string relativePath = Path.Combine("Properties", "launchSettings.json");
+                string json = project.GetFileContentsInProject(relativePath);
+                Assert.Contains(TemplateProject.ProjectName, json);
+                Assert.Contains("Docker", json);
+                Assert.Contains("api/v1/health", json);
+            }
+        }
+    }
+}

--- a/src/Arcus.Templates.Tests.Integration/Worker/Configuration/LaunchSettingsTests.cs
+++ b/src/Arcus.Templates.Tests.Integration/Worker/Configuration/LaunchSettingsTests.cs
@@ -1,0 +1,42 @@
+﻿using System.IO;
+using Arcus.Templates.Tests.Integration.Fixture;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Arcus.Templates.Tests.Integration.Worker.Configuration
+{
+    [Trait("Category", TestTraits.Integration)]
+    public class LaunchSettingsTests
+    {
+        private readonly ITestOutputHelper _outputWriter;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LaunchSettingsTests" /> class.
+        /// </summary>
+        public LaunchSettingsTests(ITestOutputHelper outputWriter)
+        {
+            _outputWriter = outputWriter;
+        }
+
+        [Theory]
+        [InlineData(ServiceBusEntityType.Queue)]
+        [InlineData(ServiceBusEntityType.Topic)]
+        public void WorkerTemplate_WithDefault_ConfiguresLaunchSettings(ServiceBusEntityType entityType)
+        {
+            // Arrange
+            var config = TestConfig.Create();
+            var options = ServiceBusWorkerProjectOptions.Create(config);
+
+            // Act
+            using (var project = ServiceBusWorkerProject.CreateNew(entityType, config, options, _outputWriter))
+            {
+                // Assert
+                string relativePath = Path.Combine("Properties", "launchSettings.json");
+                string json = project.GetFileContentsInProject(relativePath);
+                Assert.Contains(TemplateProject.ProjectName, json);
+                Assert.Contains("Docker", json);
+            }
+        }
+    }
+}

--- a/src/Arcus.Templates.Tests.Integration/Worker/ServiceBusWorkerProject.cs
+++ b/src/Arcus.Templates.Tests.Integration/Worker/ServiceBusWorkerProject.cs
@@ -3,6 +3,7 @@ using Arcus.Templates.Tests.Integration.Fixture;
 using Arcus.Templates.Tests.Integration.Worker.Configuration;
 using Arcus.Templates.Tests.Integration.Worker.ServiceBus.Fixture;
 using GuardNet;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Xunit.Abstractions;
 
@@ -33,7 +34,7 @@ namespace Arcus.Templates.Tests.Integration.Worker
         /// </returns>
         public static async Task<ServiceBusWorkerProject> StartNewWithQueueAsync(ITestOutputHelper outputWriter)
         {
-            Guard.NotNull(outputWriter, nameof(outputWriter));
+            Guard.NotNull(outputWriter, nameof(outputWriter), "Requires a test logger to add telemetry information during the creation and startup process");
 
             var config = TestConfig.Create();
             var options = ServiceBusWorkerProjectOptions.Create(config);
@@ -56,9 +57,9 @@ namespace Arcus.Templates.Tests.Integration.Worker
             ServiceBusWorkerProjectOptions options,
             ITestOutputHelper outputWriter)
         {
-            Guard.NotNull(config, nameof(config));
-            Guard.NotNull(options, nameof(options));
-            Guard.NotNull(outputWriter, nameof(outputWriter));
+            Guard.NotNull(config, nameof(config), "Requires an integration test configuration to configure the resulting project from the Service Bus worker template");
+            Guard.NotNull(options, nameof(options), "Requires a set of options to configure the resulting project from the Service Bus worker template");
+            Guard.NotNull(outputWriter, nameof(outputWriter), "Requires a test logger to add telemetry information during the creation and startup process");
 
             ServiceBusWorkerProject project = await StartNewAsync(ServiceBusEntityType.Queue, config, options, outputWriter);
             return project;
@@ -73,7 +74,7 @@ namespace Arcus.Templates.Tests.Integration.Worker
         /// </returns>
         public static async Task<ServiceBusWorkerProject> StartNewWithTopicAsync(ITestOutputHelper outputWriter)
         {
-            Guard.NotNull(outputWriter, nameof(outputWriter));
+            Guard.NotNull(outputWriter, nameof(outputWriter), "Requires a test logger to add telemetry information during the creation and startup process");
 
             var config = TestConfig.Create();
             var options = ServiceBusWorkerProjectOptions.Create(config);
@@ -96,9 +97,9 @@ namespace Arcus.Templates.Tests.Integration.Worker
             ServiceBusWorkerProjectOptions options,
             ITestOutputHelper outputWriter)
         {
-            Guard.NotNull(config, nameof(config));
-            Guard.NotNull(options, nameof(options));
-            Guard.NotNull(outputWriter, nameof(outputWriter));
+            Guard.NotNull(config, nameof(config), "Requires an integration test configuration to configure the resulting project from the Service Bus worker template");
+            Guard.NotNull(options, nameof(options), "Requires a set of options to configure the resulting project from the Service Bus worker template");
+            Guard.NotNull(outputWriter, nameof(outputWriter), "Requires a test logger to add telemetry information during the creation and startup process");
 
             ServiceBusWorkerProject project = await StartNewAsync(ServiceBusEntityType.Topic, config, options, outputWriter);
             return project;
@@ -112,7 +113,7 @@ namespace Arcus.Templates.Tests.Integration.Worker
         /// <param name="options">The project options to manipulate the resulting structure of the project.</param>
         /// <param name="outputWriter">The output logger to add telemetry information during the creation and startup process.</param>
         /// <returns>
-        ///     A ServiceBus Queue project with a set of services to interact with the worker.
+        ///     A ServiceBus project with a set of services to interact with the worker.
         /// </returns>
         public static async Task<ServiceBusWorkerProject> StartNewAsync(
             ServiceBusEntityType entityType, 
@@ -120,6 +121,10 @@ namespace Arcus.Templates.Tests.Integration.Worker
             ServiceBusWorkerProjectOptions options, 
             ITestOutputHelper outputWriter)
         {
+            Guard.NotNull(configuration, nameof(configuration), "Requires an integration test configuration to configure the resulting project from the Service Bus worker template");
+            Guard.NotNull(options, nameof(options), "Requires a set of options to configure the resulting project from the Service Bus worker template");
+            Guard.NotNull(outputWriter, nameof(outputWriter), "Requires a test logger to add telemetry information during the creation and startup process");
+
             ServiceBusWorkerProject project = CreateNew(entityType, configuration, options, outputWriter);
 
             EventGridConfig eventGridConfig = configuration.GetEventGridConfig();
@@ -133,12 +138,26 @@ namespace Arcus.Templates.Tests.Integration.Worker
             return project;
         }
 
-        private static ServiceBusWorkerProject CreateNew(
+        /// <summary>
+        /// Creates a new project from the ServiceBus worker project template.
+        /// </summary>
+        /// <param name="entityType">The resource entity for which the worker template should be created.</param>
+        /// <param name="configuration">The collection of configuration values to correctly initialize the resulting project with secret values.</param>
+        /// <param name="options">The project options to manipulate the resulting structure of the project.</param>
+        /// <param name="outputWriter">The output logger to add telemetry information during the creation process.</param>
+        /// <returns>
+        ///     A ServiceBus project with a set of services to interact with the worker.
+        /// </returns>
+        public static ServiceBusWorkerProject CreateNew(
             ServiceBusEntityType entityType, 
             TestConfig configuration, 
             ServiceBusWorkerProjectOptions options,
             ITestOutputHelper outputWriter)
         {
+            Guard.NotNull(configuration, nameof(configuration), "Requires an integration test configuration to configure the resulting project from the Service Bus worker template");
+            Guard.NotNull(options, nameof(options), "Requires a set of options to configure the resulting project from the Service Bus worker template");
+            Guard.NotNull(outputWriter, nameof(outputWriter), "Requires a test logger to add telemetry information during the creation process");
+
             var project = new ServiceBusWorkerProject(entityType, configuration, outputWriter);
             project.CreateNewProject(options);
             project.AddTestMessageHandler();

--- a/src/Arcus.Templates.WebApi/Properties/launchSettings.json
+++ b/src/Arcus.Templates.WebApi/Properties/launchSettings.json
@@ -1,6 +1,5 @@
 {
   "profiles": {
-//#if (OpenApi)
     "Arcus.Templates.WebApi": {
       "commandName": "Project",
       "launchBrowser": true,
@@ -8,10 +7,13 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
+//#if (OpenApi)
       "launchUrl": "api/docs",
+//#else
+      "launchUrl": "api/v1/health",
+//#endif
       "applicationUrl": "http://localhost:4068"
     },
-//#endif
     "Docker": {
       "commandName": "Docker",
       "useSSL": false


### PR DESCRIPTION
Streamline the `/Properties/launchSettings.json` file in all project templates with both a 'Project' and 'Docker' profile to start the resulting project.

Closes #764