### PR TITLE
chore: remove 'core' in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://dev.azure.com/codit/Arcus/_apis/build/status/Commit%20builds/CI%20-%20Arcus.Templates?branchName=main)](https://dev.azure.com/codit/Arcus/_build/latest?definitionId=765&branchName=main)
 [![NuGet Badge](https://buildstats.info/nuget/Arcus.Templates.WebApi?includePreReleases=true)](https://www.nuget.org/packages/Arcus.Templates.WebApi/)
 
-.NET Core templates to simplify the new projects and applying best practices.
+.NET templates to simplify the new projects and applying best practices.
 
 ![Arcus](https://raw.githubusercontent.com/arcus-azure/arcus/master/media/arcus.png)
 


### PR DESCRIPTION
Remove 'Core' in '.NET Core templates' in the `README.md` file.